### PR TITLE
Add support for JMESPath transformation

### DIFF
--- a/Dan.Common/Enums/ErrorCode.cs
+++ b/Dan.Common/Enums/ErrorCode.cs
@@ -140,6 +140,11 @@ public enum ErrorCode
     /// </summary>
     AccreditationRepositoryException = 1026,
 
+    /// <summary>
+    /// An invalid JMES Path expression was supplied
+    /// </summary>
+    InvalidJmesPathExpressionException = 1027,
+
     ////
     //// Error codes for evidence source implementations (3xxx)
     ////

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageReference Include="GitInfo" Version="2.2.0" />
+    <PackageReference Include="JmesPath.Net" Version="1.0.205" />
     <PackageReference Include="jose-jwt" Version="4.0.1" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.11.0-preview2" />

--- a/Dan.Core/Exceptions/InvalidJmesPathExpressionException.cs
+++ b/Dan.Core/Exceptions/InvalidJmesPathExpressionException.cs
@@ -1,0 +1,37 @@
+﻿using Dan.Common.Enums;
+using Dan.Common.Exceptions;
+
+namespace Dan.Core.Exceptions;
+
+/// <summary>
+/// Invalid JMES Path Exception
+/// </summary>
+public class InvalidJmesPathExpressionException : DanException
+{
+    /// <inheritdoc />
+    public override string DefaultErrorMessage => "Failure applying JMESPath transform";
+
+    /// <summary>
+    /// Invalid JMES Path Exception
+    /// </summary>
+    public InvalidJmesPathExpressionException() : base(ErrorCode.InvalidJmesPathExpressionException)
+    {
+    }
+
+    /// <summary>
+    /// Invalid JMES Path Exception
+    /// </summary>
+    /// <param name="message">Error Message</param>
+    public InvalidJmesPathExpressionException(string? message) : base(ErrorCode.InvalidJmesPathExpressionException, message)
+    {
+    }
+
+    /// <summary>
+    /// Invalid JMES Path Exception
+    /// </summary>
+    /// <param name="message">Error message</param>
+    /// <param name="innerException">Inner exception</param>
+    public InvalidJmesPathExpressionException(string? message, Exception? innerException) : base(ErrorCode.InvalidJmesPathExpressionException, message, innerException)
+    {
+    }
+}

--- a/Dan.Core/Extensions/ExceptionExtensions.cs
+++ b/Dan.Core/Extensions/ExceptionExtensions.cs
@@ -73,6 +73,7 @@ public static class ExceptionExtensions
             case InvalidAuthorizationRequestException _:
             case EvidenceSourcePermanentClientException _:
             case ConsentAlreadyHandledException _:
+            case InvalidJmesPathExpressionException _:
                 return HttpStatusCode.BadRequest; // 400
             case MissingAuthenticationException _:
             case InvalidAccessTokenException _:

--- a/Dan.Core/FuncDirectHarvester.cs
+++ b/Dan.Core/FuncDirectHarvester.cs
@@ -3,6 +3,7 @@ using Dan.Common.Enums;
 using Dan.Common.Models;
 using Dan.Core.Exceptions;
 using Dan.Core.Extensions;
+using Dan.Core.Helpers;
 using Dan.Core.Services;
 using Dan.Core.Services.Interfaces;
 using Microsoft.Azure.Functions.Worker;
@@ -92,7 +93,7 @@ namespace Dan.Core
             var response = req.CreateResponse(HttpStatusCode.OK);
             if (req.HasQueryParam("envelope") && !req.GetBoolQueryParam("envelope"))
             {
-                await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues);
+                await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues, req.GetQueryParam(JmesPathTransfomer.QueryParameter));
             }
             else
             {
@@ -141,6 +142,7 @@ namespace Dan.Core
                 "subject",
                 "code",
                 "envelope",
+                JmesPathTransfomer.QueryParameter,
                 RequestContextService.QueryParamReuseToken,
                 RequestContextService.QueryParamTokenOnBehalfOfOwner
             };

--- a/Dan.Core/FuncEvidenceHarvester.cs
+++ b/Dan.Core/FuncEvidenceHarvester.cs
@@ -79,7 +79,7 @@ namespace Dan.Core
             var response = req.CreateResponse(HttpStatusCode.OK);
             if (req.HasQueryParam("envelope") && !req.GetBoolQueryParam("envelope"))
             {
-                await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues);
+                await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues, req.GetQueryParam(JmesPathTransfomer.QueryParameter));
             }
             else
             {

--- a/Dan.Core/FuncOpenData.cs
+++ b/Dan.Core/FuncOpenData.cs
@@ -6,6 +6,7 @@ using Dan.Common.Services;
 using Dan.Core.Attributes;
 using Dan.Core.Exceptions;
 using Dan.Core.Extensions;
+using Dan.Core.Helpers;
 using Dan.Core.Services.Interfaces;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
@@ -56,7 +57,7 @@ namespace Dan.Core
             var evidencecode = await ValidateDatasetName(datasetName);
             var evidence = await _evidenceHarvesterService.HarvestOpenData(evidencecode, identifier);
             var response = req.CreateResponse(HttpStatusCode.OK);
-            await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues);
+            await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues, req.GetQueryParam(JmesPathTransfomer.QueryParameter));
 
             _logger.DanLog(identifier, datasetName, "OpenData", LogAction.OpenDataRetrieved);
 

--- a/Dan.Core/Helpers/JmesPathTransfomer.cs
+++ b/Dan.Core/Helpers/JmesPathTransfomer.cs
@@ -1,0 +1,26 @@
+﻿using Dan.Core.Exceptions;
+using DevLab.JmesPath;
+
+namespace Dan.Core.Helpers;
+
+public static class JmesPathTransfomer
+{
+    public const string QueryParameter = "query";
+    public static void Apply(string? jmesExpression, ref string jsonResult)
+    {
+        if (string.IsNullOrEmpty(jmesExpression) || string.IsNullOrEmpty(jsonResult))
+        {
+            return;
+        }
+
+        try
+        {
+            var jmes = new JmesPath();
+            jsonResult = jmes.Transform(jsonResult, jmesExpression);
+        }
+        catch (Exception e)
+        {
+            throw new InvalidJmesPathExpressionException(e.Message);
+        }
+    }
+}


### PR DESCRIPTION
### Description
This adds support for [JMESPath](https://jmespath.org/) via https://github.com/jdevillard/JmesPath.Net . A URL parameter, `query`, is added for all harvest endpoints (ignored if using envelope) as well as metadata-endpoints.

### Tasks
- [x] Doc updated
- [x] APIM terraform endpoint updated
- [x] Security considerations
