### PR TITLE
Add support for streaming non-encoded binaries from plugins

### DIFF
--- a/Dan.Common/Enums/EvidenceValueType.cs
+++ b/Dan.Common/Enums/EvidenceValueType.cs
@@ -30,7 +30,7 @@ public enum EvidenceValueType
     DateTime = 4,
 
     /// <summary>
-    /// Binary attachment
+    /// Binary attachment (Base64-encoded)
     /// </summary>
     [EnumMember(Value = "attachment")]
     Attachment = 5,
@@ -48,8 +48,14 @@ public enum EvidenceValueType
     Amount = 7,
 
     /// <summary>
-    /// Currency value
+    /// Arbitrary JSON
     /// </summary>
     [EnumMember(Value = "jsonSchema")]
-    JsonSchema = 8
+    JsonSchema = 8,
+
+    /// <summary>
+    /// Raw binary (only available without envelope, cannot be combined with other values)
+    /// </summary>
+    [EnumMember(Value = "binary")]
+    Binary = 9,
 }

--- a/Dan.Core/FuncDirectHarvester.cs
+++ b/Dan.Core/FuncDirectHarvester.cs
@@ -50,29 +50,25 @@ namespace Dan.Core
             HttpRequestData req,
             string evidenceCodeName)
         {
-
             await _requestContextService.BuildRequestContext(req);
 
             var authorizationRequest = await GetAuthorizationRequest(req, evidenceCodeName);
-
             await _authorizationRequestValidatorService.Validate(authorizationRequest);
-            var evidenceCodes = _authorizationRequestValidatorService.GetEvidenceCodes();
-            
-            if (evidenceCodes.Any(x => x.IsAsynchronous ||  (x.AuthorizationRequirements ?? new List<Requirement>()).Any(y => y is ConsentRequirement)))
+            var evidenceCodeForHarvest = _authorizationRequestValidatorService.GetEvidenceCodes().First();
+
+            if (evidenceCodeForHarvest.IsAsynchronous ||  evidenceCodeForHarvest.AuthorizationRequirements.Any(y => y is ConsentRequirement))
             {
                 throw new InvalidEvidenceRequestException("Unable to directly harvest async or consent-based evidence code");
             }
 
-            foreach (var es in evidenceCodes)
-            {
-                es.AuthorizationRequirements = new List<Requirement>();
-            }
+            evidenceCodeForHarvest.AuthorizationRequirements = new List<Requirement>();
 
+            // Create a dummy accreditation for the harvest
             var validTo = _authorizationRequestValidatorService.GetValidTo();
             var accreditation = new Accreditation
             {
                 AccreditationId = Guid.NewGuid().ToString(),
-                EvidenceCodes = evidenceCodes,
+                EvidenceCodes = new List<EvidenceCode> { evidenceCodeForHarvest },
                 Requestor = authorizationRequest.Requestor,
                 RequestorParty = authorizationRequest.RequestorParty,
                 Subject = authorizationRequest.Subject,
@@ -87,23 +83,35 @@ namespace Dan.Core
                 ServiceContext = _requestContextService.ServiceContext.Name
             };
 
-            var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _requestContextService.GetEvidenceHarvesterOptionsFromRequest());
-            _logger.DanLog(accreditation, LogAction.AuthorizationGranted);
-
             var response = req.CreateResponse(HttpStatusCode.OK);
-            if (req.HasQueryParam("envelope") && !req.GetBoolQueryParam("envelope"))
+            
+            if (evidenceCodeForHarvest.Values.Any(x => x.ValueType == EvidenceValueType.Binary))
             {
-                await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues, req.GetQueryParam(JmesPathTransfomer.QueryParameter));
+                // Binary content, "stream" response to client, This is not actually streaming, as 
+                // the HttpResponseData representation does not provide access to the actual HttpRequest. 
+                response.Headers.Add("Content-Type", "application/octet-stream");
+                var upstreamResponse = await _evidenceHarvesterService.HarvestStream(evidenceCodeName, accreditation,
+                    _requestContextService.GetEvidenceHarvesterOptionsFromRequest());
+
+                await upstreamResponse.CopyToAsync(response.Body);
             }
             else
             {
-                await response.SetEvidenceAsync(evidence);
+                var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _requestContextService.GetEvidenceHarvesterOptionsFromRequest());
+                if (req.HasQueryParam("envelope") && !req.GetBoolQueryParam("envelope"))
+                {
+                    await response.SetUnenvelopedEvidenceValuesAsync(evidence.EvidenceValues, req.GetQueryParam(JmesPathTransfomer.QueryParameter));
+                }
+                else
+                {
+                    await response.SetEvidenceAsync(evidence);
+                }    
             }
-
+            
+            _logger.DanLog(accreditation, LogAction.AuthorizationGranted);            
             _logger.DanLog(accreditation, LogAction.DataRetrieved);
 
             return response;
-            
         }
 
         private static async Task<AuthorizationRequest> GetAuthorizationRequest(HttpRequestData req, string evidenceCodeName)

--- a/Dan.Core/Services/Interfaces/IEvidenceHarvesterService.cs
+++ b/Dan.Core/Services/Interfaces/IEvidenceHarvesterService.cs
@@ -5,5 +5,6 @@ namespace Dan.Core.Services.Interfaces;
 public interface IEvidenceHarvesterService
 {
     Task<Evidence> Harvest(string evidenceCodeName, Accreditation accreditation, EvidenceHarvesterOptions? evidenceHarvesterOptions = default);
+    Task<Stream> HarvestStream(string evidenceCodeName, Accreditation accreditation, EvidenceHarvesterOptions? evidenceHarvesterOptions = default);
     Task<Evidence> HarvestOpenData(EvidenceCode evidenceCodeName, string identifier = "");
 }


### PR DESCRIPTION
### Description
This adds support for harvesting non-encoded/enveloped binary evidence values from plugins, which performs better on larger non-structured files since we avoid a lot of JSON marshalling. This also implements streaming of said binaries, however the  out-of-process functions model does not yet support this, so the entire content needs to be buffered on each hop (plugin worker -> plugin host -> core worker -> core host -> client). This causes significant delay before the first byte is received at the client. This change, however, by avoiding Base64-encoding, mitigates this.