### PR TITLE
Up timeout for plugins to respond to evidence code refresh

### DIFF
--- a/Dan.Core/Program.cs
+++ b/Dan.Core/Program.cs
@@ -160,7 +160,7 @@ var host = new HostBuilder()
         services.AddHttpClient("EvidenceCodesClient", client =>
             {
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
-                client.Timeout = TimeSpan.FromSeconds(10);
+                client.Timeout = TimeSpan.FromSeconds(25);
             })
             .AddHttpMessageHandler<ExceptionDelegatingHandler>();
 


### PR DESCRIPTION
### Description
Log analytics show that skatt and tilda regularly hit 15-20 seconds cold start times, causing the evidence code refresh to treat it as timed out/dead. As a triaging measure pending optimized start up times in these plugins, we up the timeout value to 25 seconds.
