### PR TITLE
chore(deps): upgrade application insights packages out of preview version

### DIFF
--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />

--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="AsyncKeyedLock" Version="6.4.2" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0-preview4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="7.0.20" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Dan.Common/Extensions/EvidenceHarvesterRequestExtension.cs
+++ b/Dan.Common/Extensions/EvidenceHarvesterRequestExtension.cs
@@ -75,7 +75,7 @@ public static class EvidenceHarvesterRequestExtension
             return false;
         }
 
-        return DateTime.TryParse(parameter?.Value.ToString(), out value);
+        return DateTime.TryParse(parameter?.Value?.ToString(), out value);
     }
 
 

--- a/Dan.Common/Extensions/HostBuilderExtensions.cs
+++ b/Dan.Common/Extensions/HostBuilderExtensions.cs
@@ -27,14 +27,7 @@ public static class HostBuilderExtensions
     public static IHostBuilder ConfigureDanPluginDefaults(this IHostBuilder builder)
     {
         builder
-            .ConfigureFunctionsWorkerDefaults(workerBuilder =>
-            {
-                workerBuilder
-                    // Using preview package Microsoft.Azure.Functions.Worker.ApplicationInsights, see https://github.com/Azure/azure-functions-dotnet-worker/pull/944
-                    // Requires APPLICATIONINSIGHTS_CONNECTION_STRING being set. Note that host.json logging settings are not loaded to worker, and requires
-                    .AddApplicationInsights()
-                    .AddApplicationInsightsLogger();
-            }, options =>
+            .ConfigureFunctionsWorkerDefaults(_ =>{}, options =>
             {
                 options.Serializer = new NewtonsoftJsonObjectSerializer(
                     // Use Newtonsoft.Json for serializing in order to support TypeNameHandling and other annotations on. This should be ported to System.Text.Json at some point.
@@ -53,6 +46,8 @@ public static class HostBuilderExtensions
             {
                 services.AddLogging();
                 services.AddHttpClient();
+                services.AddApplicationInsightsTelemetryWorkerService();
+                services.ConfigureFunctionsApplicationInsights();
 
                 // You will need extra configuration because AI will only log per default Warning (default AI configuration). As this is a provider-specific
                 // setting, it will override all non-provider (Logging:LogLevel)-based configurations. 

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -42,7 +42,7 @@
     <PackageReference Include="jose-jwt" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.0.0-preview4" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -40,6 +40,7 @@
     </PackageReference>
     <PackageReference Include="JmesPath.Net" Version="1.0.330" />
     <PackageReference Include="jose-jwt" Version="4.1.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="1.2.0" />

--- a/Dan.Core/Program.cs
+++ b/Dan.Core/Program.cs
@@ -56,23 +56,15 @@ var host = new HostBuilder()
 
         builder.UseMiddleware<DiagnosticsHeaderInjectionMiddleware>();
         builder.UseMiddleware<FunctionContextAccessorMiddleware>();
-
-        if (!danHostingEnvironment.IsLocalDevelopment())
-        {
-            // Using preview package Microsoft.Azure.Functions.Worker.ApplicationInsights, see https://github.com/Azure/azure-functions-dotnet-worker/pull/944
-            // Requires APPLICATIONINSIGHTS_CONNECTION_STRING being set. Note that host.json logging settings only affects the host, not the workers. 
-            // See worker-logging.json for other logging settings, and the discussion on https://github.com/Azure/azure-functions-dotnet-worker/issues/1182
-            builder
-                .AddApplicationInsights()
-                .AddApplicationInsightsLogger();
-        }
-
     }, options =>
     {
         options.Serializer = new NewtonsoftJsonObjectSerializer();
     })
     .ConfigureServices((_, services) =>
     {
+        services.AddApplicationInsightsTelemetryWorkerService();
+        services.ConfigureFunctionsApplicationInsights();
+        
         // You will need extra configuration because above will only log per default Warning (default AI configuration). As this is a provider-specific
         // setting, it will override all non-provider (Logging:LogLevel)-based configurations. 
         // https://github.com/microsoft/ApplicationInsights-dotnet/blob/main/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs#L427


### PR DESCRIPTION
### Description
Ref https://github.com/data-altinn-no/core/pull/71
The non-preview version of implementing application insights has changed a bit, instead of configuring the worker builder, it is registered to the service container.

See MS docs, based it off that: https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide?tabs=windows#application-insights

### Documentation
- [ ] Doc updated
