### PR TITLE
feat: upgrade project to .NET 8

### DIFF
--- a/Dan.Common.UnitTest/Dan.Common.UnitTest.csproj
+++ b/Dan.Common.UnitTest/Dan.Common.UnitTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
 

--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
+++ b/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/Dan.Core.UnitTest/Helpers/AssertHelper.cs
+++ b/Dan.Core.UnitTest/Helpers/AssertHelper.cs
@@ -70,14 +70,5 @@ namespace Dan.Core.UnitTest.Helpers
         public NotSameContentsException(string message, Exception innerException) : base(message, innerException)
         {
         }
-
-        /// <summary>
-        /// Not same contents exception
-        /// </summary>
-        /// <param name="info">Serialization Info</param>
-        /// <param name="context">Streaming context</param>
-        protected NotSameContentsException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
     }
 }

--- a/Dan.Core.UnitTest/Startup.cs
+++ b/Dan.Core.UnitTest/Startup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.Configuration;
 namespace Dan.Core.UnitTest;
 
 [TestClass]
-class GlobalTestInitializer
+public class GlobalTestInitializer
 {
     [AssemblyInitialize()]
     public static void MyTestInitialize(TestContext testContext)

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.10.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.10.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="7.0.20" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />


### PR DESCRIPTION
### Description
Simple upgrade to .NET 8, upgraded azure functions sdk package to support .NET 8 (why this was a minor version upgrade idk but functions do be functions)

Remove an unused code snippet that caused a warning, added a public keyword to class that was decorated with attribute that causes warning if not public

### Documentation
- [ ] Doc updated
