### PR TITLE
feat: allow duplicate evidence value keys

### DIFF
--- a/Dan.Core/Helpers/JsonConverters/KeyValueListAsObjectConverter.cs
+++ b/Dan.Core/Helpers/JsonConverters/KeyValueListAsObjectConverter.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+
+namespace Dan.Core.Helpers.JsonConverters;
+
+// Solution found here: https://stackoverflow.com/questions/68069271/how-to-serialize-and-deserialize-a-json-object-with-duplicate-property-names-in
+public class KeyValueListAsObjectConverter<TValue> : JsonConverter<List<KeyValuePair<string, TValue>>>
+{
+    public override List<KeyValuePair<string, TValue>> ReadJson(
+        JsonReader reader,
+        Type objectType,
+        List<KeyValuePair<string, TValue>>? existingValue,
+        bool hasExistingValue,
+        JsonSerializer serializer)
+    {
+        // We don't need to read this format
+        throw new NotImplementedException();
+    }
+
+    public override void WriteJson(JsonWriter writer, List<KeyValuePair<string, TValue>>? value, JsonSerializer serializer)
+    {
+        writer.WriteStartObject();
+        foreach (var pair in value ?? [])
+        {
+            writer.WritePropertyName(pair.Key);
+            serializer.Serialize(writer, pair.Value);
+        }
+        writer.WriteEndObject();
+    }
+}


### PR DESCRIPTION
### Description
Tilda has multiple evidence values with the same key (tilsynsrapporter). This caused issue with envelope=false, as that made use of a hash table to serialize the evidence values before applying jmespath expression.

Adding a custom converter that serializes a keyvaluepair list to the same result as a hashtable would. This means the json can have duplicate properties, which isn't malformed, but not exactly the best practice either, but it will behave as expected

https://github.com/data-altinn-no/core/issues/10

### Documentation
- [ ] Doc updated
