### PR TITLE
added altinn studio apps servicecontext

### DIFF
--- a/Dan.Core/Services/ServiceContextService.cs
+++ b/Dan.Core/Services/ServiceContextService.cs
@@ -251,6 +251,24 @@ public class ServiceContextService : IServiceContextService
                     new MaskinportenScopeRequirement{RequiredScopes = ["dan:test"]}
                 ],
                 ServiceContextTextTemplate = new DanTestServiceContextTextTemplate()
+            },
+            new ServiceContext()
+            {
+                Name = "Altinn Studio-apps",
+                Id = "altinnstudioapps-product",
+                ValidLanguages = new List<string>() {Constants.LANGUAGE_CODE_NORWEGIAN_NB },
+                AuthorizationRequirements = new List<Requirement>()
+                {
+                    new MaskinportenScopeRequirement()
+                    {
+                        RequiredScopes = new List<string>() { "dan:altinnstudioapps" }
+                    },
+                    new ProvideOwnTokenRequirement(),
+                    new AccreditationPartyRequirement()
+                    {
+                        PartyRequirements = new List<AccreditationPartyRequirementType>() { AccreditationPartyRequirementType.RequestorAndOwnerAreEqual }
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
### Description
Add new service context for altinn studio apps - all datasets will require client-provided authentication token to be used against the datasources

### Documentation
- [ ] Doc updated
