### PR TITLE
feat: add support for dataset aliases

### DIFF
--- a/Dan.Common/Models/EvidenceCode.cs
+++ b/Dan.Common/Models/EvidenceCode.cs
@@ -138,4 +138,12 @@ public class EvidenceCode
     [DataMember(Name = "timeout")]
     [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public int? Timeout { get; set; }
+    
+    /// <summary>
+    /// Optional setting for aliases. Key is service context, value is Dataset name
+    /// Allows for the same dataset to be shared between service contexts with different names.
+    /// </summary>
+    [DataMember(Name = "datasetAliases")]
+    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    public Dictionary<string,string>? DatasetAliases { get; set; }
 }

--- a/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
+++ b/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="7.0.0"/>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />

--- a/Dan.Core.UnitTest/EvidenceHarvesterServiceTest.cs
+++ b/Dan.Core.UnitTest/EvidenceHarvesterServiceTest.cs
@@ -24,6 +24,7 @@ namespace Dan.Core.UnitTest
         private readonly Mock<IEvidenceStatusService> _mockEvidenceStatusService = new();
         private readonly Mock<ITokenRequesterService> _mockTokenRequesterService = new();
         private readonly Mock<IRequestContextService> _mockRequestContextService = new();
+        private readonly Mock<IAvailableEvidenceCodesService> _mockAvailableEvidenceCodesService = new();
 
         private const string CONSENT_DENIED = "denied";
 
@@ -61,7 +62,14 @@ namespace Dan.Core.UnitTest
             );
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG);
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var response = await evidenceHarvesterService.Harvest(EVIDENCECODE_OPEN, accreditation);
 
@@ -84,7 +92,14 @@ namespace Dan.Core.UnitTest
             _mockConsentService.Setup(_ => _.GetJwt(It.IsAny<Accreditation>())).Returns(Task.FromResult("somejwt"));
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG);
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var response = await evidenceHarvesterService.Harvest(EVIDENCECODE_CONSENT, accreditation);
 
@@ -106,7 +121,14 @@ namespace Dan.Core.UnitTest
             );
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, null);
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<RequiresConsentException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_CONSENT, accreditation));
             StringAssert.Contains(actual.Result.Message, "pending a reply to the consent request");
@@ -126,7 +148,14 @@ namespace Dan.Core.UnitTest
             );
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, null, CONSENT_DENIED);
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<RequiresConsentException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_CONSENT, accreditation));
             StringAssert.Contains(actual.Result.Message, "evidence code has been denied or revoked");
@@ -146,7 +175,14 @@ namespace Dan.Core.UnitTest
             );
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, DateTime.Now.AddDays(-1));
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<RequiresConsentException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_CONSENT, accreditation));
             StringAssert.Contains(actual.Result.Message, "evidence code has expired");
@@ -167,7 +203,14 @@ namespace Dan.Core.UnitTest
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG);
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<AsyncEvidenceStillWaitingException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_ASYNC, accreditation));
             StringAssert.Contains(actual.Result.Message, "The data for the requested evidence is not yet available");
@@ -191,7 +234,14 @@ namespace Dan.Core.UnitTest
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG);
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<ServiceNotAvailableException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_OPEN, accreditation));
             StringAssert.Contains(actual.Result.Message, "unable to retrieve authentication token");
@@ -216,7 +266,14 @@ namespace Dan.Core.UnitTest
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, DateTime.Now.AddDays(-1));
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
 
             var actual = Assert.ThrowsExceptionAsync<AsyncEvidenceStillWaitingException>(() => evidenceHarvesterService.Harvest(EVIDENCECODE_ASYNC, accreditation));
             StringAssert.Contains(actual.Result.Message, "The data for the requested evidence is not yet available");
@@ -237,7 +294,14 @@ namespace Dan.Core.UnitTest
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, DateTime.Now.AddDays(-1));
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
             var response = await evidenceHarvesterService.Harvest(EVIDENCECODE_ASYNC, accreditation);
 
             Assert.AreEqual((int)StatusCodeId.Available, response.EvidenceStatus.Status.Code);
@@ -259,7 +323,14 @@ namespace Dan.Core.UnitTest
 
             Accreditation accreditation = MakeAccreditation("aid", Certificates.DEFAULT_ORG, DateTime.Now.AddDays(-1));
 
-            var evidenceHarvesterService = new EvidenceHarvesterService(_loggerFactory, _mockHttpClientFactory.Object, _mockConsentService.Object, _mockEvidenceStatusService.Object, _mockTokenRequesterService.Object, _mockRequestContextService.Object);
+            var evidenceHarvesterService = new EvidenceHarvesterService(
+                _loggerFactory, 
+                _mockHttpClientFactory.Object, 
+                _mockConsentService.Object, 
+                _mockEvidenceStatusService.Object, 
+                _mockTokenRequesterService.Object, 
+                _mockRequestContextService.Object,
+                _mockAvailableEvidenceCodesService.Object);
             var response = await evidenceHarvesterService.HarvestStream(EVIDENCECODE_STREAM, accreditation);
 
             var sr = new StreamReader(response);

--- a/Dan.Core.UnitTest/appsettings.unittest.json
+++ b/Dan.Core.UnitTest/appsettings.unittest.json
@@ -9,7 +9,7 @@
   "AccreditationMaximumValidDays": 10,
   "AccreditationMinimumValidDays": 1,
   "DoffinLinkTemplate": "{0}",
-  "EvidenceSources": "ut1,ut2",
+  "EvidenceSources": "ut1",
   "EvidenceSourceURLPattern": "http://%s.unittest.net/api/evidencecodes,",
   "FunctionKeyValue": "x",
   "ASPNETCORE_ENVIRONMENT": "LocalDevelopment" 

--- a/Dan.Core/Extensions/EvidenceCodeExtensions.cs
+++ b/Dan.Core/Extensions/EvidenceCodeExtensions.cs
@@ -12,10 +12,12 @@ public static class EvidenceCodeExtensions
     /// Gets the full URL to the evidence code 
     /// </summary>
     /// <param name="evidenceCode">The evidence code instance</param>
+    /// <param name="aliases">Collection of evidence code aliases</param>
     /// <returns>A fully qualified URL</returns>
-    public static string GetEvidenceSourceUrl(this EvidenceCode evidenceCode)
+    public static string GetEvidenceSourceUrl(this EvidenceCode evidenceCode, Dictionary<string, string> aliases)
     {
-        return Settings.GetEvidenceSourceUrl(evidenceCode.EvidenceSource).Replace("/api/evidencecodes", $"/api/{evidenceCode.EvidenceCodeName}?code={Settings.FunctionKeyValue}");
+        var evidenceCodeName = aliases?.GetValueOrDefault(evidenceCode.EvidenceCodeName) ?? evidenceCode.EvidenceCodeName;
+        return Settings.GetEvidenceSourceUrl(evidenceCode.EvidenceSource).Replace("/api/evidencecodes", $"/api/{evidenceCodeName}?code={Settings.FunctionKeyValue}");
     }
 
     /// <summary>

--- a/Dan.Core/FuncAuthorization.cs
+++ b/Dan.Core/FuncAuthorization.cs
@@ -21,6 +21,7 @@ public class FuncAuthorization
     private readonly IAuthorizationRequestValidatorService _authorizationRequestValidatorService;
     private readonly IRequestContextService _requestContextService;
     private readonly IAccreditationRepository _accreditationRepository;
+    private readonly IAvailableEvidenceCodesService _availableEvidenceCodesService;
     private readonly ILogger<FuncAuthorization> _logger;
 
     public FuncAuthorization(
@@ -29,7 +30,8 @@ public class FuncAuthorization
         IConsentService consentService,
         IAuthorizationRequestValidatorService authorizationRequestValidatorService,
         IRequestContextService requestContextService,
-        IAccreditationRepository accreditationRepository)
+        IAccreditationRepository accreditationRepository, 
+        IAvailableEvidenceCodesService availableEvidenceCodesService)
     {
         _logger = loggerFactory.CreateLogger<FuncAuthorization>();
         _client = httpClientFactory.CreateClient("SafeHttpClient");
@@ -37,6 +39,7 @@ public class FuncAuthorization
         _authorizationRequestValidatorService = authorizationRequestValidatorService;
         _requestContextService = requestContextService;
         _accreditationRepository = accreditationRepository;
+        _availableEvidenceCodesService = availableEvidenceCodesService;
     }
 
     /// <summary>
@@ -90,7 +93,8 @@ public class FuncAuthorization
             using (var t = _logger.Timer($"{evidenceCode.EvidenceCodeName}-init"))
             {
                 _logger.LogInformation("Start init async evidenceCode={evidenceCode} aid={accreditationId}", evidenceCode.EvidenceCodeName, accreditation.AccreditationId);
-                await EvidenceSourceHelper.InitAsynchronousEvidenceCodeRequest(accreditation, evidenceCode, _client);
+                var aliases = _availableEvidenceCodesService.GetAliases();
+                await EvidenceSourceHelper.InitAsynchronousEvidenceCodeRequest(accreditation, evidenceCode, _client, aliases);
                 _logger.LogInformation("Completed init async evidenceCode={evidenceCode} aid={accreditationId} elapsedMs={elapsedMs}", evidenceCode.EvidenceCodeName, accreditation.AccreditationId, t.ElapsedMilliseconds);
             }
         }

--- a/Dan.Core/Helpers/EvidenceSourceHelper.cs
+++ b/Dan.Core/Helpers/EvidenceSourceHelper.cs
@@ -105,10 +105,11 @@ public static class EvidenceSourceHelper
     /// <param name="accreditation">The associated accreditation</param>
     /// <param name="evidenceCode">The evidence code to initialize</param>
     /// <param name="client">The HTTP client</param>
+    /// <param name="aliases">Evidence code aliases</param>
     /// <returns>Nothing, but will throw if the call fails or the evidence source reports and error</returns>
-    public static async Task InitAsynchronousEvidenceCodeRequest(Accreditation accreditation, EvidenceCode evidenceCode, HttpClient client)
+    public static async Task InitAsynchronousEvidenceCodeRequest(Accreditation accreditation, EvidenceCode evidenceCode, HttpClient client, Dictionary<string, string> aliases)
     {
-        var url = evidenceCode.GetEvidenceSourceUrl();
+        var url = evidenceCode.GetEvidenceSourceUrl(aliases);
 
         var request = new HttpRequestMessage(HttpMethod.Post, url);
 

--- a/Dan.Core/Services/AvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/AvailableEvidenceCodesService.cs
@@ -276,7 +276,10 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
                 aliasedEvidenceCode.DatasetAliases = null;
                 aliasedEvidenceCode.AuthorizationRequirements = aliasedEvidenceCode
                     .AuthorizationRequirements
-                    .Where(a => a.AppliesToServiceContext.Contains(alias.Key)).ToList();
+                    .Where(a =>
+                        a.AppliesToServiceContext.Count == 0 ||
+                        a.AppliesToServiceContext.Contains(alias.Key))
+                    .ToList();
                 
                 splitEvidenceCodes.Add(aliasedEvidenceCode);
             }

--- a/Dan.Core/Services/AvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/AvailableEvidenceCodesService.cs
@@ -64,7 +64,7 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
         if (!forceRefresh && DateTime.UtcNow < _updateMemoryCache)
         {
             SetCacheDiagnosticsHeader("hit-local");
-            return FilterInactive(_memoryCache);
+            return FilterEvidenceCodes(_memoryCache);
         }
 
         if (forceRefresh)
@@ -74,7 +74,7 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
             using (await _semaphoreForceRefresh.LockAsync())
             {
                 await RefreshEvidenceCodesCache();
-                return FilterInactive(_memoryCache);
+                return FilterEvidenceCodes(_memoryCache);
             }
         }
 
@@ -85,15 +85,31 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
             if (DateTime.UtcNow < _updateMemoryCache)
             {
                 SetCacheDiagnosticsHeader("hit-local-late");
-                return FilterInactive(_memoryCache);
+                return FilterEvidenceCodes(_memoryCache);
             }
 
             // This uses Polly to get from the distributed cache, or refresh from source if Redis cache is expired.
             _memoryCache = await GetAvailableEvidenceCodesFromDistributedCache();
             _updateMemoryCache = DateTime.UtcNow.AddSeconds(MemoryCacheTtlSeconds);
 
-            return FilterInactive(_memoryCache);
+            return FilterEvidenceCodes(_memoryCache);
         }
+    }
+
+    public Dictionary<string, string> GetAliases()
+    {
+        var aliases = new Dictionary<string, string>();
+        var aliasedEvidenceCodes = _memoryCache
+            .Where(ec => ec.DatasetAliases is not null && ec.DatasetAliases.Count > 0);
+        foreach (var aliasedEvidenceCode in aliasedEvidenceCodes)
+        {
+            foreach (var alias in aliasedEvidenceCode.DatasetAliases!)
+            {
+                aliases.Add(alias.Value, aliasedEvidenceCode.EvidenceCodeName);
+            }
+        }
+
+        return aliases;
     }
 
     private void SetCacheDiagnosticsHeader(string value, bool overwrite = false)
@@ -233,9 +249,42 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
         return sources;
     }
 
+    private static List<EvidenceCode> FilterEvidenceCodes(IEnumerable<EvidenceCode> evidenceCodes)
+    {
+        evidenceCodes = FilterInactive(evidenceCodes);
+        evidenceCodes = SplitAliases(evidenceCodes);
+        return evidenceCodes.ToList();
+    }
     private static List<EvidenceCode> FilterInactive(IEnumerable<EvidenceCode> evidenceCodes)
     {
         return evidenceCodes.Where(IsDatasetValid).ToList();
+    }
+
+    private static List<EvidenceCode> SplitAliases(IEnumerable<EvidenceCode> evidenceCodes)
+    {
+        var evidenceCodesList = evidenceCodes.ToList();
+        var aliasedEvidenceCodes = evidenceCodesList.Where(e => e.DatasetAliases != null && e.DatasetAliases.Count != 0).ToList();
+        var splitEvidenceCodes = new List<EvidenceCode>();
+        foreach (var evidenceCode in aliasedEvidenceCodes)
+        {
+            foreach (var alias in evidenceCode.DatasetAliases!)
+            {
+                var aliasedEvidenceCode = evidenceCode.DeepCopy();
+                aliasedEvidenceCode.ServiceContext = alias.Key;
+                aliasedEvidenceCode.BelongsToServiceContexts = [alias.Key];
+                aliasedEvidenceCode.EvidenceCodeName = alias.Value;
+                aliasedEvidenceCode.DatasetAliases = null;
+                aliasedEvidenceCode.AuthorizationRequirements = aliasedEvidenceCode
+                    .AuthorizationRequirements
+                    .Where(a => a.AppliesToServiceContext.Contains(alias.Key)).ToList();
+                
+                splitEvidenceCodes.Add(aliasedEvidenceCode);
+            }
+
+            evidenceCodesList.Remove(evidenceCode);
+        }
+        evidenceCodesList.AddRange(splitEvidenceCodes);
+        return evidenceCodesList;
     }
 
     private static bool IsDatasetValid(EvidenceCode dataSet)

--- a/Dan.Core/Services/EvidenceStatusService.cs
+++ b/Dan.Core/Services/EvidenceStatusService.cs
@@ -146,7 +146,8 @@ public class EvidenceStatusService : IEvidenceStatusService
 
     private async Task<EvidenceStatusCode> GetAsynchronousEvidenceStatusCode(Accreditation accreditation, EvidenceCode evidenceCode)
     {
-        var url = evidenceCode.GetEvidenceSourceUrl();
+        var aliases = _availableEvidenceCodesService.GetAliases();
+        var url = evidenceCode.GetEvidenceSourceUrl(aliases);
 
         var request = new HttpRequestMessage(HttpMethod.Post, url);
         request.Headers.TryAddWithoutValidation("Accept", "application/json");

--- a/Dan.Core/Services/Interfaces/IAvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/Interfaces/IAvailableEvidenceCodesService.cs
@@ -5,4 +5,6 @@ namespace Dan.Core.Services.Interfaces;
 public interface IAvailableEvidenceCodesService
 {
     public Task<List<EvidenceCode>> GetAvailableEvidenceCodes(bool forceRefresh = false);
+
+    public Dictionary<string, string> GetAliases();
 }

--- a/Dan.PluginTest/Config/PluginConstants.cs
+++ b/Dan.PluginTest/Config/PluginConstants.cs
@@ -1,0 +1,13 @@
+﻿namespace Dan.PluginTest.Config;
+
+public static class PluginConstants
+{
+    public const int ErrorUpstreamUnavailble = 1001;
+    public const int ErrorInvalidInput = 1002;
+    public const int ErrorNotFound = 1003;
+    public const int ErrorUnableToParseResponse = 1004;
+    
+    public const string Source = "Source";
+    public const string DatasetOne = "DatasetOne";
+    public const string DatasetTwo = "DatasetTwo";
+}

--- a/Dan.PluginTest/Config/Settings.cs
+++ b/Dan.PluginTest/Config/Settings.cs
@@ -1,0 +1,6 @@
+﻿namespace Dan.PluginTest.Config;
+
+public class Settings
+{
+    
+}

--- a/Dan.PluginTest/Dan.PluginTest.csproj
+++ b/Dan.PluginTest/Dan.PluginTest.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <AzureFunctionsVersion>v4</AzureFunctionsVersion>
+        <OutputType>Exe</OutputType>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" OutputItemType="Analyzer" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
+        <PackageReference Include="NJsonSchema" Version="11.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Update="host.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Update="local.settings.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+            <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+        </None>
+    </ItemGroup>
+    <ItemGroup>
+        <Using Include="System.Threading.ExecutionContext" Alias="ExecutionContext"/>
+    </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\Dan.Common\Dan.Common.csproj" />
+    </ItemGroup>
+</Project>

--- a/Dan.PluginTest/Metadata.cs
+++ b/Dan.PluginTest/Metadata.cs
@@ -1,0 +1,75 @@
+﻿using System.Net;
+using Dan.Common;
+using Dan.Common.Enums;
+using Dan.Common.Interfaces;
+using Dan.Common.Models;
+using Dan.PluginTest.Config;
+using Dan.PluginTest.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using NJsonSchema;
+
+namespace Dan.PluginTest;
+
+public class Metadata : IEvidenceSourceMetadata
+{
+    private const string DanTest = "DAN-test";
+    private const string AltinnStudioApps = "Altinn Studio-apps";
+    private readonly List<string> _serviceContexts = [DanTest,AltinnStudioApps];
+
+    [Function(Constants.EvidenceSourceMetadataFunctionName)]
+    public async Task<HttpResponseData> GetMetadataAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = null)] HttpRequestData req,
+        FunctionContext context)
+    {
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(GetEvidenceCodes());
+        return response;
+    }
+
+    public List<EvidenceCode> GetEvidenceCodes()
+    {
+        return
+        [
+            new EvidenceCode
+            {
+                EvidenceCodeName = PluginConstants.DatasetOne,
+                EvidenceSource = PluginConstants.Source,
+                BelongsToServiceContexts = _serviceContexts,
+                DatasetAliases = new Dictionary<string, string>()
+                {
+                    { DanTest, "AliasOne" },
+                    { AltinnStudioApps, "AliasTwo" },
+                },
+                Values =
+                [
+                    new EvidenceValue
+                    {
+                        EvidenceValueName = "default",
+                        ValueType = EvidenceValueType.JsonSchema,
+                        JsonSchemaDefintion = JsonSchema
+                            .FromType<DatasetResponse>()
+                            .ToJson(Newtonsoft.Json.Formatting.Indented)
+                    }
+                ]
+            },
+            new EvidenceCode
+            {
+                EvidenceCodeName = PluginConstants.DatasetTwo,
+                EvidenceSource = PluginConstants.Source,
+                ServiceContext = DanTest,
+                Values =
+                [
+                    new EvidenceValue
+                    {
+                        EvidenceValueName = "default",
+                        ValueType = EvidenceValueType.JsonSchema,
+                        JsonSchemaDefintion = JsonSchema
+                            .FromType<DatasetResponse>()
+                            .ToJson(Newtonsoft.Json.Formatting.Indented)
+                    }
+                ]
+            }
+        ];
+    }
+}

--- a/Dan.PluginTest/Models/DatasetResponse.cs
+++ b/Dan.PluginTest/Models/DatasetResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Dan.PluginTest.Models;
+
+[Serializable]
+public class DatasetResponse
+{
+    [JsonProperty("test")]
+    public string? Test { get; set; }
+}

--- a/Dan.PluginTest/Plugin.cs
+++ b/Dan.PluginTest/Plugin.cs
@@ -1,0 +1,87 @@
+﻿using Dan.Common.Exceptions;
+using Dan.Common.Interfaces;
+using Dan.Common.Models;
+using Dan.Common.Util;
+using Dan.PluginTest.Config;
+using Dan.PluginTest.Models;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Dan.PluginTest;
+
+// ReSharper disable once ClassNeverInstantiated.Global
+public class Plugin(
+    ILoggerFactory loggerFactory,
+    IEvidenceSourceMetadata evidenceSourceMetadata)
+{
+    private readonly ILogger _logger = loggerFactory.CreateLogger<Plugin>();
+    
+    [Function(PluginConstants.DatasetOne)]
+    public async Task<HttpResponseData> DatasetOne(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
+        FunctionContext context)
+    {
+        EvidenceHarvesterRequest? evidenceHarvesterRequest;
+        try
+        {
+            evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Exception while attempting to parse request into EvidenceHarvesterRequest: {exceptionType}: {exceptionMessage}",
+                e.GetType().Name, e.Message);
+            throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput,
+                "Unable to parse request", e);
+        }
+
+        return await EvidenceSourceResponse.CreateResponse(req,
+            () => GetEvidenceValuesDatasetOne(evidenceHarvesterRequest));
+    }
+    
+    [Function(PluginConstants.DatasetTwo)]
+    public async Task<HttpResponseData> DatasetTwo(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
+        FunctionContext context)
+    {
+        EvidenceHarvesterRequest? evidenceHarvesterRequest;
+        try
+        {
+            evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Exception while attempting to parse request into EvidenceHarvesterRequest: {exceptionType}: {exceptionMessage}",
+                e.GetType().Name, e.Message);
+            throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput,
+                "Unable to parse request", e);
+        }
+
+        return await EvidenceSourceResponse.CreateResponse(req,
+            () => GetEvidenceValuesDatasetTwo(evidenceHarvesterRequest));
+    }
+    
+    private async Task<List<EvidenceValue>> GetEvidenceValuesDatasetOne(
+        EvidenceHarvesterRequest? evidenceHarvesterRequest)
+    {
+        var response = new DatasetResponse{Test = "DatasetOne"};
+        var ecb = new EvidenceBuilder(evidenceSourceMetadata, PluginConstants.DatasetOne);
+        ecb.AddEvidenceValue("default", response, PluginConstants.Source);
+
+        await Task.CompletedTask;
+        return ecb.GetEvidenceValues();
+    }
+    
+    private async Task<List<EvidenceValue>> GetEvidenceValuesDatasetTwo(
+        EvidenceHarvesterRequest? evidenceHarvesterRequest)
+    {
+        var response = new DatasetResponse{Test = "DatasetTwo"};
+        var ecb = new EvidenceBuilder(evidenceSourceMetadata, PluginConstants.DatasetOne);
+        ecb.AddEvidenceValue("default", response, PluginConstants.Source);
+
+        await Task.CompletedTask;
+        return ecb.GetEvidenceValues();
+    }
+}

--- a/Dan.PluginTest/Program.cs
+++ b/Dan.PluginTest/Program.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Hosting;
+using Dan.Common.Extensions;
+using Dan.PluginTest.Config;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+var host = new HostBuilder()
+    .ConfigureDanPluginDefaults()
+    .ConfigureAppConfiguration((_, _) =>
+    {
+    })
+    .ConfigureServices((context, services) =>
+    {
+        var configurationRoot = context.Configuration;
+        services.Configure<Settings>(configurationRoot);
+
+        var applicationSettings = services.BuildServiceProvider().GetRequiredService<IOptions<Settings>>().Value;
+    })
+    .Build();
+
+await host.RunAsync();

--- a/Dan.PluginTest/Properties/launchSettings.json
+++ b/Dan.PluginTest/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+  "profiles": {
+    "Dan.PluginTest": {
+      "commandName": "Project",
+      "commandLineArgs": "--port 7102",
+      "launchBrowser": false
+    }
+  }
+}

--- a/Dan.PluginTest/host.json
+++ b/Dan.PluginTest/host.json
@@ -1,0 +1,12 @@
+{
+    "version": "2.0",
+    "logging": {
+        "applicationInsights": {
+            "samplingSettings": {
+                "isEnabled": true,
+                "excludedTypes": "Request"
+            },
+            "enableLiveMetricsFilters": true
+        }
+    }
+}

--- a/Dan.sln
+++ b/Dan.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dan.Core.UnitTest", "Dan.Co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dan.Common.UnitTest", "Dan.Common.UnitTest\Dan.Common.UnitTest.csproj", "{9B7CB8FD-7827-48D6-895E-0F79C27FD0EE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dan.PluginTest", "Dan.PluginTest\Dan.PluginTest.csproj", "{DCC63854-2460-4404-83FE-E8CCC132A637}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,6 +38,10 @@ Global
 		{9B7CB8FD-7827-48D6-895E-0F79C27FD0EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9B7CB8FD-7827-48D6-895E-0F79C27FD0EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9B7CB8FD-7827-48D6-895E-0F79C27FD0EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCC63854-2460-4404-83FE-E8CCC132A637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCC63854-2460-4404-83FE-E8CCC132A637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCC63854-2460-4404-83FE-E8CCC132A637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCC63854-2460-4404-83FE-E8CCC132A637}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### Description
Update EvidenceCode model to support dataset aliases

This means you can create an evidence code in a plugin, set aliases for different service contexts, and dancore will display them as two separate datasets. When someone tries to harvest data from the alias, dancore will translate it back to the real dataset.

Also added a simple test plugin in the repo in order to test changes to common and core without needing to rely on other repos/plugins c:

### Documentation
- [ ] Doc updated
