### PR TITLE
remove parameter copy from metadata to evidenceharvesterrequest for o…

### DIFF
--- a/Dan.Core/Services/EvidenceHarvesterService.cs
+++ b/Dan.Core/Services/EvidenceHarvesterService.cs
@@ -102,8 +102,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         {
             OrganizationNumber = identifier,
             SubjectParty = PartyParser.GetPartyFromIdentifier(identifier, out string? _),
-            EvidenceCodeName = evidenceCode.EvidenceCodeName,
-            Parameters = evidenceCode.Parameters
+            EvidenceCodeName = evidenceCode.EvidenceCodeName           
         };
 
         using (var _ = _log.Timer($"{evidenceCode.EvidenceCodeName}-harvest"))


### PR DESCRIPTION
…pen data

### Description
Open data harvests included a copy of all params from evidencecode metadata causing all parameter checks to fail because the requests has params but none of them have values. Since we do not support params on the open data endpoint including them seems pointless

### Documentation
- [ ] Doc updated
