### PR TITLE
feat: add support for azure auth to plugins

### DIFF
--- a/Dan.Common/Constants.cs
+++ b/Dan.Common/Constants.cs
@@ -14,6 +14,8 @@ public static class Constants
     public const string SafeHttpClient = "SafeHttpClient";
 
     public const string SafeHttpClientPolicy = "SafeHttpClientPolicy";
+    
+    public const string PluginHttpClient = "PluginHttpClient";
 
     public const string LANGUAGE_CODE_NORWEGIAN_NB = "no-nb";
 

--- a/Dan.Common/Enums/ErrorCode.cs
+++ b/Dan.Common/Enums/ErrorCode.cs
@@ -144,6 +144,16 @@ public enum ErrorCode
     /// An invalid JMES Path expression was supplied
     /// </summary>
     InvalidJmesPathExpressionException = 1027,
+    
+    /// <summary>
+    /// Exception from upstream
+    /// </summary>
+    UpstreamException = 1028,
+    
+    /// <summary>
+    /// Quota exceeded
+    /// </summary>
+    QuotaExceededException = 1029,
 
     ////
     //// Error codes for evidence source implementations (3xxx)

--- a/Dan.Common/Handlers/PluginAuthorizationMessageHandler.cs
+++ b/Dan.Common/Handlers/PluginAuthorizationMessageHandler.cs
@@ -1,0 +1,45 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Microsoft.Extensions.Configuration;
+
+namespace Dan.Common.Handlers;
+
+// Source: https://stackoverflow.com/questions/71187362/azure-function-to-azure-function-request-using-defaultazurecredential-and-httpcl
+/// <summary>
+/// Adds bearer token with azure credentials for scope
+/// </summary>
+public class PluginAuthorizationMessageHandler : DelegatingHandler
+{
+    private readonly IConfiguration _configuration;
+    private readonly DefaultAzureCredential _credentials;
+
+    /// <summary>
+    /// Base constructor for azure credential handler
+    /// </summary>
+    public PluginAuthorizationMessageHandler(IConfiguration configuration)
+    {
+        _configuration = configuration;
+        _credentials = new DefaultAzureCredential();
+    }
+
+    /// <summary>
+    /// Adds bearer token to http request
+    /// </summary>
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        // Usually just need one scope, api://{{guid}}/.default, but supports more for special cases
+        var scopes = _configuration.GetSection("PluginScopes").Value?.Split(",");
+    
+        // No scopes? We just send. If something requires a scope, then add that to app settings
+        if (scopes is not { Length: > 0 })
+        {
+            return await base.SendAsync(request, cancellationToken);
+        }
+    
+        var tokenRequestContext = new TokenRequestContext(scopes);
+        var tokenResult = await _credentials.GetTokenAsync(tokenRequestContext, cancellationToken);
+        var authorizationHeader = new AuthenticationHeaderValue("Bearer", tokenResult.Token);
+        request.Headers.Authorization = authorizationHeader;
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Dan.Common/Services/DanPluginClientService.cs
+++ b/Dan.Common/Services/DanPluginClientService.cs
@@ -1,0 +1,132 @@
+﻿using System.Text;
+using Dan.Common.Exceptions;
+
+namespace Dan.Common.Services;
+
+/// <summary>
+/// Service for calling DAN plugins
+/// </summary>
+public interface IDanPluginClientService
+{
+    /// <summary>
+    /// Get dataset value
+    /// </summary>
+    public Task<T?> GetPluginDataSetAsync<T>(EvidenceHarvesterRequest request, string code, string env, bool isDefaultJson, string url = "", string source = "") where T: new();
+}
+
+/// <summary>
+/// Service for calling DAN plugins
+/// </summary>
+public class DanPluginClientService : IDanPluginClientService
+{
+    private readonly HttpClient _httpClient;
+    private const string MetadataDev = "https://dev-api.data.altinn.no/v1/public/metadata/evidencecodes";
+    private const string MetadataTest = "https://test-api.data.altinn.no/v1/public/metadata/evidencecodes";
+    private const string MetadataProd = "https://api.data.altinn.no/v1/public/metadata/evidencecodes";
+    private const string PluginDev = "https://func-es{0}-test-dev.azurewebsites.net/api/{1}?code={2}";
+    private const string PluginTest = "https://func-es{0}-prod-prod-staging.azurewebsites.net/api/{1}?code={2}";
+    private const string PluginProd = "https://func-es{0}-prod-prod.azurewebsites.net/api/{1}?code={2}";
+
+    /// <summary>
+    /// Sets up service with a safe http client built from provided factory
+    /// </summary>
+    public DanPluginClientService(IHttpClientFactory httpClientFactory)
+    {
+        _httpClient = httpClientFactory.CreateClient(Constants.PluginHttpClient);
+    }
+    
+    /// <summary>
+    /// Get dataset value
+    /// </summary>
+    public async Task<T?> GetPluginDataSetAsync<T>(EvidenceHarvesterRequest request, string code, string env, bool isDefaultJson, string pluginUrl = "", string source = "") where T : new()
+    {
+        HttpResponseMessage? response = default;
+        var result = default(T);
+        try
+        {
+            var url = env switch
+                {
+                    "dev" => MetadataDev,
+                    "test" => MetadataTest,
+                    "prod" => MetadataProd,
+                    _ => throw new ArgumentOutOfRangeException(nameof(env), "env must be dev, test or prod"),
+                };
+            
+            var metadataResponse = await _httpClient.GetAsync(url);
+            
+            EvidenceCode? evidenceCode;
+            if (metadataResponse.IsSuccessStatusCode)
+            {
+                var evidenceCodes = JsonConvert.DeserializeObject<List<EvidenceCode>>(await metadataResponse.Content.ReadAsStringAsync());
+                evidenceCode = evidenceCodes?.FirstOrDefault(x => x.EvidenceCodeName == request.EvidenceCodeName);
+                if (evidenceCode == null)
+                {
+                    throw new EvidenceSourceTransientException(1, "Dataset not found");
+                }
+                if (!string.IsNullOrEmpty(evidenceCode.RequiredScopes))
+                {
+                    throw new ArgumentOutOfRangeException(nameof(request.MPToken), $"Dataset requires maskinporten token which was not supplied");
+                }
+            }
+            else
+            {
+                throw new EvidenceSourceTransientException(1, "Dataset not found");
+            }
+            pluginUrl = string.IsNullOrEmpty(pluginUrl) ? GetPluginUrl(env, source, evidenceCode.EvidenceCodeName, code) : pluginUrl;
+            response = await _httpClient.PostAsync(pluginUrl, new StringContent(JsonConvert.SerializeObject(request),Encoding.UTF8, "application/json"));
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                {
+                    var content = await response.Content.ReadAsStringAsync();
+                    if (isDefaultJson)
+                    {
+                        var evidenceValues = JsonConvert.DeserializeObject<List<EvidenceValue>>(content);
+                        var evidenceValue = evidenceValues?.First(x => x.EvidenceValueName == "default");
+                        if (evidenceValue?.Value is null)
+                        {
+                            return result;
+                        }
+
+                        var stringvalue = evidenceValue.Value.ToString();
+                        result = JsonConvert.DeserializeObject<T>(stringvalue!);
+                    }
+                    else
+                    {
+                        result = JsonConvert.DeserializeObject<T>(content);
+                    }
+                }
+                    break;
+                case HttpStatusCode.NoContent:
+                    throw new EvidenceSourcePermanentClientException((int)ErrorCode.UpstreamException, "Unexpected HTTP status code from external API, no content found");
+                case HttpStatusCode.BadRequest:
+                    throw new EvidenceSourcePermanentClientException((int)ErrorCode.UpstreamException, "Bad request");
+                case HttpStatusCode.UnprocessableEntity:
+                    throw new EvidenceSourceTransientException((int)ErrorCode.QuotaExceededException, "Quota exceeded. Try again tomorrow.");
+                default:
+                    throw new EvidenceSourcePermanentClientException((int)ErrorCode.UpstreamException, "Unexpected HTTP status code from external API");
+            }
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new EvidenceSourcePermanentServerException((int)ErrorCode.UpstreamException, null, ex);
+        }
+        finally
+        {
+            response?.Dispose();
+        }
+        return result;
+    }
+    
+    private static string GetPluginUrl(string env, string source, string evidenceCodeName, string code)
+    {
+        var result = env switch
+        {
+            "dev" => string.Format(PluginDev, source, evidenceCodeName, code),
+            "test" => string.Format(PluginTest, source, evidenceCodeName, code),
+            "prod" => string.Format(PluginProd, source, evidenceCodeName, code),
+            _ => throw new ArgumentOutOfRangeException(nameof(env), $"env must be dev, test or prod"),
+        };
+        return result;
+    }
+}

--- a/Dan.Core/Services/AvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/AvailableEvidenceCodesService.cs
@@ -1,4 +1,5 @@
-﻿using Dan.Common.Models;
+﻿using System.Net.Http.Headers;
+using Dan.Common.Models;
 using Dan.Core.Config;
 using Dan.Core.Extensions;
 using Dan.Core.Services.Interfaces;
@@ -11,6 +12,7 @@ using Dan.Core.Helpers;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using AsyncKeyedLock;
+using Azure.Identity;
 
 namespace Dan.Core.Services;
 
@@ -205,9 +207,16 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
     private async Task<List<EvidenceCode>> GetEvidenceCodesFromSource(EvidenceSource source)
     {
         var client = _httpClientFactory.CreateClient(HttpClientName);
-
         try
         {
+            // TEMP CODE pls
+            var creds = new DefaultAzureCredential();
+            var token = await creds.GetTokenAsync(new Azure.Core.TokenRequestContext([
+                ".default"
+            ]));
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+            // VERY TEMP ABOVE make handler first pls just for testing
+            
             var request = new HttpRequestMessage(HttpMethod.Get, source.Url);
             request.Headers.Add("Accept", "application/json");
             var response = await client.SendAsync(request);

--- a/Dan.Core/Services/AvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/AvailableEvidenceCodesService.cs
@@ -209,14 +209,6 @@ public class AvailableEvidenceCodesService : IAvailableEvidenceCodesService
         var client = _httpClientFactory.CreateClient(HttpClientName);
         try
         {
-            // TEMP CODE pls
-            var creds = new DefaultAzureCredential();
-            var token = await creds.GetTokenAsync(new Azure.Core.TokenRequestContext([
-                ".default"
-            ]));
-            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
-            // VERY TEMP ABOVE make handler first pls just for testing
-            
             var request = new HttpRequestMessage(HttpMethod.Get, source.Url);
             request.Headers.Add("Accept", "application/json");
             var response = await client.SendAsync(request);

--- a/Dan.Core/Services/EvidenceHarvesterService.cs
+++ b/Dan.Core/Services/EvidenceHarvesterService.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+﻿using Dan.Common;
 using Dan.Common.Enums;
 using Dan.Common.Models;
 using Dan.Core.Config;
@@ -113,7 +113,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
 
             try
             {
-                var client = _httpClientFactory.CreateClient("SafeHttpClient");
+                var client = _httpClientFactory.CreateClient(Constants.PluginHttpClient);
                 harvestedEvidence = (await EvidenceSourceHelper.DoRequest<List<EvidenceValue>>(
                     request,
                     () => client.SendAsync(request, cts.Token)))!;
@@ -146,7 +146,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         request.SetPolicyExecutionContext(new Context(request.Key(CacheArea.Absolute)));
         try
         {
-            var client = _httpClientFactory.CreateClient("SafeHttpClient");
+            var client = _httpClientFactory.CreateClient(Constants.PluginHttpClient);
             
             // When attempting to stream from the evidence source, we simplify error handling
             var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
@@ -176,7 +176,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         request.SetPolicyExecutionContext(new Context(request.Key(CacheArea.Absolute)));
         try
         {
-            var client = _httpClientFactory.CreateClient("SafeHttpClient");
+            var client = _httpClientFactory.CreateClient(Constants.PluginHttpClient);
             return (await EvidenceSourceHelper.DoRequest<List<EvidenceValue>>(
                 request,
                 () => client.SendAsync(request, cts.Token)))!;

--- a/Dan.Core/Services/EvidenceStatusService.cs
+++ b/Dan.Core/Services/EvidenceStatusService.cs
@@ -1,4 +1,5 @@
-﻿using Dan.Common.Enums;
+﻿using Dan.Common;
+using Dan.Common.Enums;
 using Dan.Common.Models;
 using Dan.Core.Extensions;
 using Dan.Core.Helpers;
@@ -168,7 +169,7 @@ public class EvidenceStatusService : IEvidenceStatusService
         };
 
         request.JsonContent(evidenceHarvesterRequest);
-        var client = _clientFactory.CreateClient("SafeHttpClient");
+        var client = _clientFactory.CreateClient(Constants.PluginHttpClient);
 
         return (await EvidenceSourceHelper.DoRequest<EvidenceStatusCode>(
             request,

--- a/Dan.PluginTest/Config/PluginConstants.cs
+++ b/Dan.PluginTest/Config/PluginConstants.cs
@@ -10,4 +10,6 @@ public static class PluginConstants
     public const string Source = "Source";
     public const string DatasetOne = "DatasetOne";
     public const string DatasetTwo = "DatasetTwo";
+    
+    public const string PluginForward = "PluginForward";
 }

--- a/Dan.PluginTest/Config/Settings.cs
+++ b/Dan.PluginTest/Config/Settings.cs
@@ -2,5 +2,5 @@
 
 public class Settings
 {
-    
+    public string PluginCode { get; set; }
 }

--- a/Dan.PluginTest/Metadata.cs
+++ b/Dan.PluginTest/Metadata.cs
@@ -69,6 +69,20 @@ public class Metadata : IEvidenceSourceMetadata
                             .ToJson(Newtonsoft.Json.Formatting.Indented)
                     }
                 ]
+            },
+            new EvidenceCode
+            {
+                EvidenceCodeName = PluginConstants.PluginForward,
+                EvidenceSource = PluginConstants.Source,
+                ServiceContext = DanTest,
+                Values =
+                [
+                    new EvidenceValue
+                    {
+                        EvidenceValueName = "default",
+                        ValueType = EvidenceValueType.JsonSchema
+                    }
+                ]
             }
         ];
     }

--- a/Dan.PluginTest/Plugin.cs
+++ b/Dan.PluginTest/Plugin.cs
@@ -1,22 +1,28 @@
 ﻿using Dan.Common.Exceptions;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
+using Dan.Common.Services;
 using Dan.Common.Util;
 using Dan.PluginTest.Config;
 using Dan.PluginTest.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Dan.PluginTest;
 
 // ReSharper disable once ClassNeverInstantiated.Global
 public class Plugin(
     ILoggerFactory loggerFactory,
-    IEvidenceSourceMetadata evidenceSourceMetadata)
+    IEvidenceSourceMetadata evidenceSourceMetadata,
+    IDanPluginClientService danPluginClientService,
+    IOptions<Settings> settings)
 {
     private readonly ILogger _logger = loggerFactory.CreateLogger<Plugin>();
+    private readonly Settings _settings = settings.Value;
     
+    // Used to test aliases
     [Function(PluginConstants.DatasetOne)]
     public async Task<HttpResponseData> DatasetOne(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
@@ -40,6 +46,7 @@ public class Plugin(
             () => GetEvidenceValuesDatasetOne(evidenceHarvesterRequest));
     }
     
+    // Used to test aliases
     [Function(PluginConstants.DatasetTwo)]
     public async Task<HttpResponseData> DatasetTwo(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
@@ -63,6 +70,30 @@ public class Plugin(
             () => GetEvidenceValuesDatasetTwo(evidenceHarvesterRequest));
     }
     
+    // Used to test IDanPluginClientService for plugin to plugic calls
+    [Function(PluginConstants.PluginForward)]
+    public async Task<HttpResponseData> PluginForward(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
+        FunctionContext context)
+    {
+        EvidenceHarvesterRequest? evidenceHarvesterRequest;
+        try
+        {
+            evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Exception while attempting to parse request into EvidenceHarvesterRequest: {exceptionType}: {exceptionMessage}",
+                e.GetType().Name, e.Message);
+            throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput,
+                "Unable to parse request", e);
+        }
+
+        return await EvidenceSourceResponse.CreateResponse(req,
+            () => FetchPluginValue(evidenceHarvesterRequest));
+    }
+    
     private async Task<List<EvidenceValue>> GetEvidenceValuesDatasetOne(
         EvidenceHarvesterRequest? evidenceHarvesterRequest)
     {
@@ -78,10 +109,31 @@ public class Plugin(
         EvidenceHarvesterRequest? evidenceHarvesterRequest)
     {
         var response = new DatasetResponse{Test = "DatasetTwo"};
-        var ecb = new EvidenceBuilder(evidenceSourceMetadata, PluginConstants.DatasetOne);
+        var ecb = new EvidenceBuilder(evidenceSourceMetadata, PluginConstants.DatasetTwo);
         ecb.AddEvidenceValue("default", response, PluginConstants.Source);
 
         await Task.CompletedTask;
+        return ecb.GetEvidenceValues();
+    }
+    
+    private async Task<List<EvidenceValue>> FetchPluginValue(
+        EvidenceHarvesterRequest? evidenceHarvesterRequest)
+    {
+        var enovaRequest = new EvidenceHarvesterRequest
+        {
+            EvidenceCodeName = "OffentligEnergiData",
+            OrganizationNumber = "931001434"
+        };
+        
+        var response = await danPluginClientService.GetPluginDataSetAsync<dynamic>(
+            request: enovaRequest,
+            code: _settings.PluginCode,
+            env: "dev",
+            isDefaultJson: true,
+            source: "enova");
+        var ecb = new EvidenceBuilder(evidenceSourceMetadata, PluginConstants.DatasetOne);
+        ecb.AddEvidenceValue("default", response, PluginConstants.Source);
+
         return ecb.GetEvidenceValues();
     }
 }


### PR DESCRIPTION
### Description
feat: add support for azure auth to plugins

A DelegatingHandler is added to http clients that go towards plugins, allowing us to set up app authentication in Azure. Appsetting `"PluginScopes"` must be added, and said scope must be configured in the plugin auth settings.

Also adding  DanPluginClientService which allows for plugin-to-plugin communication, using the same handler described above.

### Documentation
- [ ] Doc updated
