### PR TITLE
feat: increase caching time for ec

### DIFF
--- a/Dan.Core.UnitTest/AvailableEvidenceCodesServiceTest.cs
+++ b/Dan.Core.UnitTest/AvailableEvidenceCodesServiceTest.cs
@@ -25,7 +25,6 @@ namespace Dan.Core.UnitTest
         private readonly ILoggerFactory _loggerFactory = new NullLoggerFactory();
         private readonly Mock<IHttpClientFactory> _mockHttpClientFactory = new Mock<IHttpClientFactory>();
         private readonly Mock<AsyncPolicy<List<EvidenceCode>>> _mockAsyncPolicy = new Mock<AsyncPolicy<List<EvidenceCode>>>();
-        private readonly Mock<IDistributedCache> _mockDistributedCache = new Mock<IDistributedCache>();
         private readonly Mock<IServiceContextService> _mockServiceContextService = new Mock<IServiceContextService>();
         private readonly Mock<IFunctionContextAccessor> _mockFunctionContextAccessor = new Mock<IFunctionContextAccessor>();
 
@@ -136,7 +135,6 @@ namespace Dan.Core.UnitTest
                 _loggerFactory,
                 _mockHttpClientFactory.Object,
                 _policyRegistry,
-                _mockDistributedCache.Object,
                 _mockServiceContextService.Object,
                 _mockFunctionContextAccessor.Object);
 
@@ -185,7 +183,6 @@ namespace Dan.Core.UnitTest
                 _loggerFactory,
                 _mockHttpClientFactory.Object,
                 _policyRegistry,
-                _mockDistributedCache.Object,
                 _mockServiceContextService.Object,
                 _mockFunctionContextAccessor.Object);
 


### PR DESCRIPTION
### Description
Increased the memory cache time for dancore to 10 minutes. Since it force refreshes every 5 minutes, this should be sufficient to avoid fall outs.
Also removed a part of the code that cached the evidencecodes in redis, but that was handled by polly via the policyregistry, making the code snippet unused and confusing

### Documentation
- [ ] Doc updated
