### PR TITLE
feat: add default method for generating json schema for evidence code

### DIFF
--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -40,6 +40,8 @@
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.12" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.12" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NJsonSchema" Version="11.3.2" />
+    <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.3.2" />
 
     <PackageReference Include="Polly.Caching.Distributed" Version="3.0.1" />
     <PackageReference Include="Polly.Caching.Serialization.Json" Version="3.0.0" />

--- a/Dan.Common/Models/EvidenceValue.cs
+++ b/Dan.Common/Models/EvidenceValue.cs
@@ -1,3 +1,5 @@
+using NJsonSchema.NewtonsoftJson.Generation;
+
 namespace Dan.Common.Models;
 
 /// <summary>
@@ -67,5 +69,15 @@ public class EvidenceValue : ICloneable
     public object Clone()
     {
         return MemberwiseClone();
+    }
+
+    // Default implementation of getting a json schema valid for JsonSchemaDefinition property
+    // Opted to not made a forced built in property to make it easier to custom set the property if needed
+    /// <summary>
+    /// Get JsonSchema
+    /// </summary>
+    public static string SchemaFromObject<T>(Formatting formatting = Formatting.None)
+    {
+        return NewtonsoftJsonSchemaGenerator.FromType<T>().ToJson(formatting);
     }
 }

--- a/Dan.PluginTest/Dan.PluginTest.csproj
+++ b/Dan.PluginTest/Dan.PluginTest.csproj
@@ -10,7 +10,6 @@
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" OutputItemType="Analyzer" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
-        <PackageReference Include="NJsonSchema" Version="11.1.0" />
     </ItemGroup>
     <ItemGroup>
         <None Update="host.json">

--- a/Dan.PluginTest/Metadata.cs
+++ b/Dan.PluginTest/Metadata.cs
@@ -7,7 +7,7 @@ using Dan.PluginTest.Config;
 using Dan.PluginTest.Models;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
-using NJsonSchema;
+using Newtonsoft.Json;
 
 namespace Dan.PluginTest;
 
@@ -47,9 +47,7 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         EvidenceValueName = "default",
                         ValueType = EvidenceValueType.JsonSchema,
-                        JsonSchemaDefintion = JsonSchema
-                            .FromType<DatasetResponse>()
-                            .ToJson(Newtonsoft.Json.Formatting.Indented)
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<DatasetResponse>()
                     }
                 ]
             },
@@ -64,9 +62,7 @@ public class Metadata : IEvidenceSourceMetadata
                     {
                         EvidenceValueName = "default",
                         ValueType = EvidenceValueType.JsonSchema,
-                        JsonSchemaDefintion = JsonSchema
-                            .FromType<DatasetResponse>()
-                            .ToJson(Newtonsoft.Json.Formatting.Indented)
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<DatasetResponse>(Formatting.Indented)
                     }
                 ]
             },


### PR DESCRIPTION
### Description
Simple method for generating json schema used for evidence codes
Pretty simple, but by keeping it in one place it'll make it easier to maintain it should njsonschema make other silly changes

### Documentation
- [ ] Doc updated
