### PR TITLE
feat: rewrite evidencecode caching to only use redis

### DIFF
--- a/Dan.Common/Extensions/DistributedCacheExtensions.cs
+++ b/Dan.Common/Extensions/DistributedCacheExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace Dan.Common.Extensions;
+
+/// <summary>
+/// Extension methods for IDistributedCache (i.e Redis)
+/// </summary>
+public static class DistributedCacheExtensions
+{
+    /// <summary>
+    /// Gets value from distributed cache by key and deserializes into POCO
+    /// </summary>
+    /// <typeparam name="T">Type to deserialize into</typeparam>
+    public static async Task<T?> GetValueAsync<T>(this IDistributedCache distributedCache, string key)
+    {
+        var encodedPoco = await distributedCache.GetAsync(key);
+        if (encodedPoco == null)
+        {
+            return default;
+        }
+        var serializedPoco = Encoding.UTF8.GetString(encodedPoco);
+        return JsonConvert.DeserializeObject<T>(serializedPoco);
+    }
+
+    /// <summary>
+    /// Serializes and sets value in distributed cache
+    /// </summary>
+    public static async Task SetValueAsync<T>(this IDistributedCache distributedCache, string key, T value, DistributedCacheEntryOptions? options = null)
+    {
+        options ??= new DistributedCacheEntryOptions();
+        var serializedValue = JsonConvert.SerializeObject(value);
+        var encodedValue = Encoding.UTF8.GetBytes(serializedValue);
+        await distributedCache.SetAsync(key, encodedValue, options);
+    }
+}

--- a/Dan.Core.UnitTest/AvailableEvidenceCodesServiceTest.cs
+++ b/Dan.Core.UnitTest/AvailableEvidenceCodesServiceTest.cs
@@ -27,6 +27,7 @@ namespace Dan.Core.UnitTest
         private readonly Mock<AsyncPolicy<List<EvidenceCode>>> _mockAsyncPolicy = new Mock<AsyncPolicy<List<EvidenceCode>>>();
         private readonly Mock<IServiceContextService> _mockServiceContextService = new Mock<IServiceContextService>();
         private readonly Mock<IFunctionContextAccessor> _mockFunctionContextAccessor = new Mock<IFunctionContextAccessor>();
+        private readonly Mock<IDistributedCache> _mockDistributedCache = new Mock<IDistributedCache>();
 
         private IPolicyRegistry<string> _policyRegistry;
 
@@ -135,6 +136,7 @@ namespace Dan.Core.UnitTest
                 _loggerFactory,
                 _mockHttpClientFactory.Object,
                 _policyRegistry,
+                _mockDistributedCache.Object,
                 _mockServiceContextService.Object,
                 _mockFunctionContextAccessor.Object);
 
@@ -183,6 +185,7 @@ namespace Dan.Core.UnitTest
                 _loggerFactory,
                 _mockHttpClientFactory.Object,
                 _policyRegistry,
+                _mockDistributedCache.Object,
                 _mockServiceContextService.Object,
                 _mockFunctionContextAccessor.Object);
 

--- a/Dan.Core/FuncAuthorization.cs
+++ b/Dan.Core/FuncAuthorization.cs
@@ -93,7 +93,7 @@ public class FuncAuthorization
             using (var t = _logger.Timer($"{evidenceCode.EvidenceCodeName}-init"))
             {
                 _logger.LogInformation("Start init async evidenceCode={evidenceCode} aid={accreditationId}", evidenceCode.EvidenceCodeName, accreditation.AccreditationId);
-                var aliases = _availableEvidenceCodesService.GetAliases();
+                var aliases = await _availableEvidenceCodesService.GetAliases();
                 await EvidenceSourceHelper.InitAsynchronousEvidenceCodeRequest(accreditation, evidenceCode, _client, aliases);
                 _logger.LogInformation("Completed init async evidenceCode={evidenceCode} aid={accreditationId} elapsedMs={elapsedMs}", evidenceCode.EvidenceCodeName, accreditation.AccreditationId, t.ElapsedMilliseconds);
             }

--- a/Dan.Core/Services/AvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/AvailableEvidenceCodesService.cs
@@ -1,4 +1,5 @@
 ﻿using Dan.Common.Models;
+using Dan.Common.Extensions;
 using Dan.Core.Config;
 using Dan.Core.Extensions;
 using Dan.Core.Services.Interfaces;
@@ -11,6 +12,7 @@ using Dan.Core.Helpers;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using AsyncKeyedLock;
+using Azure.Identity;
 
 namespace Dan.Core.Services;
 
@@ -18,6 +20,7 @@ public class AvailableEvidenceCodesService(
     ILoggerFactory loggerFactory,
     IHttpClientFactory httpClientFactory,
     IPolicyRegistry<string> policyRegistry,
+    IDistributedCache distributedCache,
     IServiceContextService serviceContextService,
     IFunctionContextAccessor functionContextAccessor)
     : IAvailableEvidenceCodesService
@@ -25,10 +28,7 @@ public class AvailableEvidenceCodesService(
     public static TimeSpan DistributedCacheTtl = TimeSpan.FromHours(12);
     private readonly ILogger<IAvailableEvidenceCodesService> _logger = loggerFactory.CreateLogger<AvailableEvidenceCodesService>();
 
-    private List<EvidenceCode> _memoryCache = [];
-    private DateTime _updateMemoryCache = DateTime.MinValue;
-    private readonly AsyncNonKeyedLocker _semaphoreForceRefresh = new(1);
-    private readonly AsyncNonKeyedLocker _semaphore = new(1);
+    private readonly AsyncNonKeyedLocker semaphore = new(1);
     private const int MemoryCacheTtlSeconds = 600;
 
     private const string CachingPolicy = "EvidenceCodesCachePolicy";
@@ -37,53 +37,47 @@ public class AvailableEvidenceCodesService(
     private const string CacheResponseHeader = "x-cache";
 
     /// <summary>
-    /// Gets the list of current active evidence codes. This endpoint can be hit several times during a request. In order to reduce I/O to the distributed cache, it employs
-    /// an additional layer of caching via memory. Uses semaphores to handle concurrent writes to the caches. 
+    /// Gets the list of current active evidence codes. This endpoint can be hit several times during a request.
     /// </summary>
     /// <param name="forceRefresh">If true will evict the current cache (both in-memory and distributed) and force a source-level refresh</param>
     /// <returns>A list of active evidence codes</returns>
     public async Task<List<EvidenceCode>> GetAvailableEvidenceCodes(bool forceRefresh = false)
     {
-        // Cache still valid
-        if (!forceRefresh && DateTime.UtcNow < _updateMemoryCache)
+        List<EvidenceCode>? evidenceCodes;
+        if (!forceRefresh)
         {
-            SetCacheDiagnosticsHeader("hit-local");
-            return FilterEvidenceCodes(_memoryCache);
+            evidenceCodes = await distributedCache.GetValueAsync<List<EvidenceCode>>(CacheContextKey);
+            if (evidenceCodes is not null)
+            {
+                SetCacheDiagnosticsHeader("hit-distributed");
+                return evidenceCodes;
+            }
         }
 
         if (forceRefresh)
         {
-            // Force refresh has been called. This is only performed manually or in conjuction with a deploy.
-            // Use a separate semaphore to ensure only a single thread can do this at a time without blocking other requests
-            using (await _semaphoreForceRefresh.LockAsync())
-            {
-                await RefreshEvidenceCodesCache();
-                return FilterEvidenceCodes(_memoryCache);
-            }
+            SetCacheDiagnosticsHeader("force-evict");
         }
 
-        // The memory cache is expired. We do not know if Redis cache is expired, as this is handled by Polly.
-        using (await _semaphore.LockAsync())
+        using (await semaphore.LockAsync())
         {
-            // Recheck if another thread has updated the memory cache while we were waiting for the semaphore
-            if (DateTime.UtcNow < _updateMemoryCache)
+            // Checking if another thread finished caching
+            evidenceCodes = await distributedCache.GetValueAsync<List<EvidenceCode>>(CacheContextKey);
+            if (evidenceCodes is not null)
             {
-                SetCacheDiagnosticsHeader("hit-local-late");
-                return FilterEvidenceCodes(_memoryCache);
+                return evidenceCodes;
             }
-
-            // This uses Polly to get from the distributed cache, or refresh from source if Redis cache is expired.
-            _memoryCache = await GetAvailableEvidenceCodesFromDistributedCache();
-            _updateMemoryCache = DateTime.UtcNow.AddSeconds(MemoryCacheTtlSeconds);
-
-            return FilterEvidenceCodes(_memoryCache);
+            evidenceCodes = await GetAvailableEvidenceCodesFromEvidenceSources();
+            evidenceCodes = FilterEvidenceCodes(evidenceCodes);
+            await distributedCache.SetValueAsync(CacheContextKey, evidenceCodes);
+            return evidenceCodes;
         }
     }
 
-    public Dictionary<string, string> GetAliases()
+    public async Task<Dictionary<string, string>> GetAliases()
     {
         var aliases = new Dictionary<string, string>();
-        var aliasedEvidenceCodes = _memoryCache
+        var aliasedEvidenceCodes = (await GetAvailableEvidenceCodes())
             .Where(ec => ec.DatasetAliases is not null && ec.DatasetAliases.Count > 0);
         foreach (var aliasedEvidenceCode in aliasedEvidenceCodes)
         {
@@ -109,38 +103,6 @@ public class AvailableEvidenceCodesService(
             requestContextService.CustomResponseHeaders.TryAdd(CacheResponseHeader, value);
         }
 
-    }
-
-    /// <summary>
-    /// This fetches evidence codes from the sources and updates the distributed and in-memory caches. 
-    /// </summary>
-    /// <returns>Nothing</returns>
-    private async Task RefreshEvidenceCodesCache()
-    {
-        var evidenceCodes = await GetAvailableEvidenceCodesFromEvidenceSources();
-        SetCacheDiagnosticsHeader("force-evict");
-        if (evidenceCodes.Count == 0)
-        {
-            _logger.LogWarning("Failed to refresh evidence codes cache, received empty list");
-            return;
-        }
-
-        //  Add some metadata properties to make serialized output more parseable
-        foreach (var es in evidenceCodes)
-        {
-            es.AuthorizationRequirements.ForEach(x => x.RequirementType = x.GetType().Name);
-        }
-
-        _memoryCache = evidenceCodes;
-        _updateMemoryCache = DateTime.UtcNow.AddSeconds(MemoryCacheTtlSeconds);
-    }
-
-    private async Task<List<EvidenceCode>> GetAvailableEvidenceCodesFromDistributedCache()
-    {
-        SetCacheDiagnosticsHeader("hit-distributed");
-        var cachePolicy = policyRegistry.Get<AsyncPolicy<List<EvidenceCode>>>(CachingPolicy);
-        return await cachePolicy.ExecuteAsync(
-            async _ => await GetAvailableEvidenceCodesFromEvidenceSources(), new Context(CacheContextKey));
     }
 
     private async Task<List<EvidenceCode>> GetAvailableEvidenceCodesFromEvidenceSources()
@@ -225,6 +187,10 @@ public class AvailableEvidenceCodesService(
     {
         evidenceCodes = FilterInactive(evidenceCodes);
         evidenceCodes = SplitAliases(evidenceCodes);
+        foreach (var es in evidenceCodes)
+        {
+            es.AuthorizationRequirements.ForEach(x => x.RequirementType = x.GetType().Name);
+        }
         return evidenceCodes.ToList();
     }
     private static List<EvidenceCode> FilterInactive(IEnumerable<EvidenceCode> evidenceCodes)

--- a/Dan.Core/Services/EvidenceHarvesterService.cs
+++ b/Dan.Core/Services/EvidenceHarvesterService.cs
@@ -87,7 +87,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
     {
         _log.LogDebug("Running HaaS (Harvest as a Service) for open data with dataset {evidenceCodeName} and identifier {identifier}", evidenceCode.EvidenceCodeName, identifier == "" ? "(empty)" : identifier);
         List<EvidenceValue> harvestedEvidence;
-        var aliases = _availableEvidenceCodesService.GetAliases();
+        var aliases = await _availableEvidenceCodesService.GetAliases();
         var url = evidenceCode.GetEvidenceSourceUrl(aliases);
 
         var request = new HttpRequestMessage(HttpMethod.Post, url);
@@ -191,7 +191,7 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
     private async Task<HttpRequestMessage> GetEvidenceHarvesterRequestMessage(Accreditation accreditation,
         EvidenceCode evidenceCode, EvidenceHarvesterOptions? evidenceHarvesterOptions = default)
     {
-        var aliases = _availableEvidenceCodesService.GetAliases();
+        var aliases = await _availableEvidenceCodesService.GetAliases();
         var url = evidenceCode.GetEvidenceSourceUrl(aliases);
 
         var request = new HttpRequestMessage(HttpMethod.Post, url);

--- a/Dan.Core/Services/EvidenceStatusService.cs
+++ b/Dan.Core/Services/EvidenceStatusService.cs
@@ -147,7 +147,7 @@ public class EvidenceStatusService : IEvidenceStatusService
 
     private async Task<EvidenceStatusCode> GetAsynchronousEvidenceStatusCode(Accreditation accreditation, EvidenceCode evidenceCode)
     {
-        var aliases = _availableEvidenceCodesService.GetAliases();
+        var aliases = await _availableEvidenceCodesService.GetAliases();
         var url = evidenceCode.GetEvidenceSourceUrl(aliases);
 
         var request = new HttpRequestMessage(HttpMethod.Post, url);

--- a/Dan.Core/Services/Interfaces/IAvailableEvidenceCodesService.cs
+++ b/Dan.Core/Services/Interfaces/IAvailableEvidenceCodesService.cs
@@ -6,5 +6,5 @@ public interface IAvailableEvidenceCodesService
 {
     public Task<List<EvidenceCode>> GetAvailableEvidenceCodes(bool forceRefresh = false);
 
-    public Dictionary<string, string> GetAliases();
+    public Task<Dictionary<string, string>> GetAliases();
 }


### PR DESCRIPTION
### Description
Rewritten evidencecode caching to only use redis. Old implementation was a bit hard to understand and wonky at times with desync between memory cache and redis. This simplifies it a bit.

TODO: update unit tests

### Documentation
- [ ] Doc updated
