### PR TITLE
ci: set workflow permissions

### DIFF
--- a/.github/workflows/common-release-nuget.yml
+++ b/.github/workflows/common-release-nuget.yml
@@ -1,5 +1,8 @@
 # Workflow creating a Github package
 name: Dan.Common Release Nuget
+  
+permissions:
+  actions: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/common-release-nuget.yml
+++ b/.github/workflows/common-release-nuget.yml
@@ -3,6 +3,7 @@ name: Dan.Common Release Nuget
   
 permissions:
   actions: read
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/core-cicd.yaml
+++ b/.github/workflows/core-cicd.yaml
@@ -1,4 +1,8 @@
 name: Dan.Core CI/CD
+
+permissions:
+  actions: read
+
 on:
  push:
    branches: [ master ]

--- a/.github/workflows/core-cicd.yaml
+++ b/.github/workflows/core-cicd.yaml
@@ -1,7 +1,7 @@
 name: Dan.Core CI/CD
 
 permissions:
-  actions: read
+  contents: read
 
 on:
  push:

--- a/.github/workflows/core-pr.yaml
+++ b/.github/workflows/core-pr.yaml
@@ -2,6 +2,7 @@ name: Build and test a PR
 
 permissions:
   actions: read
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/core-pr.yaml
+++ b/.github/workflows/core-pr.yaml
@@ -1,5 +1,8 @@
 name: Build and test a PR
 
+permissions:
+  actions: read
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/post-deploy-test.yml
+++ b/.github/workflows/post-deploy-test.yml
@@ -1,4 +1,6 @@
 name: Post deploy test
+permissions:
+  actions: read
 on:
  workflow_dispatch:
 jobs:

--- a/.github/workflows/post-deploy-test.yml
+++ b/.github/workflows/post-deploy-test.yml
@@ -1,6 +1,8 @@
 name: Post deploy test
 permissions:
   actions: read
+  contents: read
+  id-token: write
 on:
  workflow_dispatch:
 jobs:


### PR DESCRIPTION
### Description
<!--- What and why -->

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to tighten GitHub Actions token permissions—restricting actions and repository contents access (read-only) and granting limited identity write where needed for deployment tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->