### PR TITLE
ci: remove explicit permission lines

### DIFF
--- a/.github/workflows/post-deploy-test.yml
+++ b/.github/workflows/post-deploy-test.yml
@@ -1,15 +1,9 @@
 name: Post deploy test
-permissions:
-  actions: read
-  contents: read
-  id-token: write
-  checks: write
-  pull-requests: write
 on:
  workflow_dispatch:
 jobs:
  run:
-   uses: data-altinn-no/deploy-actions/.github/workflows/post-deploy-test.yml@28817d886fe657244d267c56480d9d0694b71f9b
+   uses: data-altinn-no/deploy-actions/.github/workflows/post-deploy-test.yml@009dae7d9c3f0ddab3c1be13fe0c76177e174d74
    with:
      environment: 'dev'
    secrets:


### PR DESCRIPTION
### Description
Attempting to remove explicit permission setting, which will set the token to default to normal read and write settings.
Strictly for testing, need to see that it's actually permissions that are breaking the job and not something else before troubleshooting further

### Documentation
- [ ] Doc updated
