### PR TITLE
feat: custom subject validation

### DIFF
--- a/Dan.Common/Models/CustomSubjectRequirement.cs
+++ b/Dan.Common/Models/CustomSubjectRequirement.cs
@@ -1,0 +1,21 @@
+﻿namespace Dan.Common.Models;
+
+/// <summary>
+/// Requirement for subjects that differ from organisation number or Norwegian SSN
+/// </summary>
+public class CustomSubjectRequirement : Requirement
+{
+    /// <summary>
+    /// Regex used to validate custom subject. Defaults to \w+ for any letters and digits
+    /// </summary>
+    [DataMember(Name = "subjectRegex")]
+    [Required]
+    public string SubjectRegex { get; set; } = @"\w+";
+
+    /// <summary>
+    /// Flag to set if should skip for checking if subject is SSN or Org number. Default to false
+    /// </summary>
+    [DataMember(Name = "skipRegularSubjectValidation")]
+    [Required]
+    public bool SkipRegularSubjectValidation { get; set; }
+}

--- a/Dan.Common/Models/CustomSubjectRequirement.cs
+++ b/Dan.Common/Models/CustomSubjectRequirement.cs
@@ -11,11 +11,11 @@ public class CustomSubjectRequirement : Requirement
     [DataMember(Name = "subjectRegex")]
     [Required]
     public string SubjectRegex { get; set; } = @"\w+";
-
+    
     /// <summary>
-    /// Flag to set if should skip for checking if subject is SSN or Org number. Default to false
+    /// Describes the regex in clear text
     /// </summary>
-    [DataMember(Name = "skipRegularSubjectValidation")]
+    [DataMember(Name = "subjectRegexDescription")]
     [Required]
-    public bool SkipRegularSubjectValidation { get; set; }
+    public string SubjectRegexDescription { get; set; } = "Any string";
 }

--- a/Dan.Core.UnitTest/Services/AuthorizationRequestValidatorServiceTest.cs
+++ b/Dan.Core.UnitTest/Services/AuthorizationRequestValidatorServiceTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using AwesomeAssertions;
 using Dan.Common.Enums;
 using Dan.Common.Models;
 using Dan.Core.Exceptions;
@@ -9,7 +10,7 @@ using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Dan.Core.UnitTest
+namespace Dan.Core.UnitTest.Services
 {
     [TestClass]
     [ExcludeFromCodeCoverage]
@@ -140,7 +141,43 @@ namespace Dan.Core.UnitTest
                 await arvs.Validate(GetAuthorizationRequest(subject: "123456789"));
             });
         }
-           
+        
+        [TestMethod]
+        [DataRow("03065001488")]
+        [DataRow("12345678")]
+        public async Task ValidateTest_CustomSubjectRequirement_ShouldSetParty(string subject)
+        {
+            // Setup
+            var ae = GetAvailableEvidenceCodes().Take(1).ToList();
+            ae.First().AuthorizationRequirements =
+            [
+                new CustomSubjectRequirement
+                {
+                    SubjectRegex = @"^\d{1,8}$", // digits only 1-8 characters long,
+                    SubjectRegexDescription = "Description",
+                    RequirementType = "CustomSubjectRequirement"
+                }
+            ];
+
+            A.CallTo(() => _mockAvailableEvidenceCodesService.GetAvailableEvidenceCodes(A<bool>._))
+                .Returns(Task.FromResult(ae));
+            
+            var arvs = new AuthorizationRequestValidatorService(
+                _loggerFactory,
+                _mockEntityRegistryService,
+                _mockAvailableEvidenceCodesService,
+                _mockRequirementValidatorService,
+                _mockRequestContextService);
+
+            var request = GetAuthorizationRequest(subject: subject);
+            
+            // Act
+            var action = async () => await arvs.Validate(request);
+            
+            // Assert
+            await action.Should().NotThrowAsync();
+            request.SubjectParty.Id.Should().Be(subject);
+        }
 
         [TestMethod]
         public async Task ValidateTestFailureWithInvalidRequestorOrgNo()

--- a/Dan.Core.UnitTest/Services/RequirementValidationServiceTest.cs
+++ b/Dan.Core.UnitTest/Services/RequirementValidationServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using Dan.Common.Enums;
+﻿using AwesomeAssertions;
+using Dan.Common.Enums;
 using Dan.Common.Models;
 using Dan.Core.Exceptions;
 using Dan.Core.Helpers;
@@ -10,7 +11,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 using ConsentRequirement = Nadobe.Common.Models.ConsentRequirement;
 
-namespace Dan.Core.UnitTest
+namespace Dan.Core.UnitTest.Services
 {
     [TestClass]
     public class RequirementValidationServiceTest
@@ -771,6 +772,140 @@ namespace Dan.Core.UnitTest
             var errorList = await svc.ValidateRequirements(req, authRequest);
             Assert.IsTrue(errorList.Count == 1);
             Assert.IsTrue(errorList[0].Contains("The request requires a valid consent reference but none is provided"));
+        }
+        
+        [TestMethod]
+        [DataRow("12345678", null)] // Custom subject
+        [DataRow("03065001488", PartyParser.NorwegianIcd)] // Already found subject in pre step
+        [DataRow("03065001488", PartyParser.SchemeIso6523ActorIdUpis)] // Already found subject in pre step
+        [DataRow("03065001488", PartyParser.SchemeNorwegianSsn)] // Already found subject in pre step
+        public async Task CustomSubjectTest_Success(string subject, string scheme)
+        {
+            // Arrange
+            var authRequest = GetAuthRequest(subject, "requestor");
+            authRequest.SubjectParty = new Party
+            {
+                Id = "12345678",
+                Scheme = scheme
+            };
+
+            var req = new Dictionary<string, List<Requirement>>
+            {
+                ["ec1"] =
+                [
+                    new CustomSubjectRequirement()
+                    {
+                        SubjectRegex = @"^\d{1,8}$"
+                    }
+                ]
+            };
+
+            var svc = new RequirementValidationService(_mockAltinnServiceOwnerApiService, _mockEntityRegistryService, _mockRequestContextService);
+            
+            // Act
+            var errorList = await svc.ValidateRequirements(req, authRequest);
+
+            // Assert
+            errorList.Should().BeEmpty();
+        }
+        
+        [TestMethod]
+        public async Task CustomSubjectTest_MismatchFormat_ShouldThrow()
+        {
+            // Arrange
+            var authRequest = GetAuthRequest("123456789", "requestor");
+            authRequest.SubjectParty = new Party
+            {
+                Id = "12345678",
+                Scheme = null
+            };
+
+            var req = new Dictionary<string, List<Requirement>>
+            {
+                ["ec1"] =
+                [
+                    new CustomSubjectRequirement()
+                    {
+                        SubjectRegex = @"^\d{1,8}$",
+                        SubjectRegexDescription = "Description"
+                    }
+                ]
+            };
+
+            var svc = new RequirementValidationService(_mockAltinnServiceOwnerApiService, _mockEntityRegistryService, _mockRequestContextService);
+            
+            // Act
+            var errorList = await svc.ValidateRequirements(req, authRequest);
+
+            // Assert
+            errorList.Should().HaveCount(1);
+            errorList.Should().Contain("ec1: Subject does not match custom subject format: Description");
+        }
+        
+        [TestMethod]
+        public async Task CustomSubjectTest_MissingSubject_ShouldThrow()
+        {
+            // Arrange
+            var authRequest = GetAuthRequest("", "requestor");
+            authRequest.SubjectParty = new Party
+            {
+                Id = "",
+                Scheme = null
+            };
+
+            var req = new Dictionary<string, List<Requirement>>
+            {
+                ["ec1"] =
+                [
+                    new CustomSubjectRequirement()
+                    {
+                        SubjectRegex = @"^\d{1,8}$",
+                        SubjectRegexDescription = "Description"
+                    }
+                ]
+            };
+
+            var svc = new RequirementValidationService(_mockAltinnServiceOwnerApiService, _mockEntityRegistryService, _mockRequestContextService);
+            
+            // Act
+            var errorList = await svc.ValidateRequirements(req, authRequest);
+
+            // Assert
+            errorList.Should().HaveCount(1);
+            errorList.Should().Contain("ec1: Subject is missing");
+        }
+        
+        [TestMethod]
+        public async Task CustomSubjectTest_MissingRegex_ShouldThrow()
+        {
+            // Arrange
+            var authRequest = GetAuthRequest("12345", "requestor");
+            authRequest.SubjectParty = new Party
+            {
+                Id = "12345",
+                Scheme = null
+            };
+
+            var req = new Dictionary<string, List<Requirement>>
+            {
+                ["ec1"] =
+                [
+                    new CustomSubjectRequirement()
+                    {
+                        SubjectRegex = "",
+                        SubjectRegexDescription = "Description"
+                    }
+                ]
+            };
+
+            var svc = new RequirementValidationService(_mockAltinnServiceOwnerApiService, _mockEntityRegistryService, _mockRequestContextService);
+            
+            // Act
+            var errorList = await svc.ValidateRequirements(req, authRequest);
+
+            // Assert
+            errorList.Should().HaveCount(1);
+            errorList.Should().Contain("ec1: Missing custom subject format regex");
         }
 
         private Requirement GetWhiteListRequirement(List<string> owners, List<string> subjects, List<string> requestors)

--- a/Dan.Core/Services/AuthorizationRequestValidatorService.cs
+++ b/Dan.Core/Services/AuthorizationRequestValidatorService.cs
@@ -69,24 +69,12 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
             }
         }
 
-        var customSubject = false;
-        var customSubjectRegex = string.Empty;
-        var skipRegularSubjectValidation = false;
-        if (requirements.Values.SelectMany(x => x).Any(req =>
-                req.RequirementType is not null &&
-                req.RequirementType.Equals("CustomSubjectRequirement", StringComparison.InvariantCultureIgnoreCase)))
-        {
-            Console.WriteLine("Found custom subject req");
-            var requirement = requirements.Values.SelectMany(x => x).First(r => r.RequirementType is not null &&
-                                                                      r.RequirementType.Equals("CustomSubjectRequirement", StringComparison.InvariantCultureIgnoreCase));
-            var customSubjectRequirement = ((CustomSubjectRequirement)requirement);
-            customSubject = true;
-            customSubjectRegex = customSubjectRequirement.SubjectRegex;
-            skipRegularSubjectValidation = customSubjectRequirement.SkipRegularSubjectValidation;
-        }
+        var customSubject = requirements.Values.SelectMany(x => x).Any(req =>
+            req.RequirementType is not null &&
+            req.RequirementType.Equals("CustomSubjectRequirement", StringComparison.InvariantCultureIgnoreCase));
         
         ValidateAndPopulateRequestor();
-        ValidateAndPopulateSubject(customSubject, skipRegularSubjectValidation, customSubjectRegex);
+        ValidateAndPopulateSubject(customSubject);
         ValidateLegalBasisWellFormed();
         ValidateEvidenceRequestWellFormed();
         ValidateEvidenceCodesAreAvailableForServiceContext();
@@ -203,50 +191,33 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
     /// Uses PartyParser on the supplied subject, and populates SubjectParty with it. Overwrites Requestor with norwegian identifier if applicable, else set to null
     /// </summary>
     /// <exception cref="InvalidSubjectException"></exception>
-    private void ValidateAndPopulateSubject(bool customSubject, bool skipRegularSubject, string? customSubjectRegex = null)
+    private void ValidateAndPopulateSubject(bool customSubject)
     {
 
         if (_authRequest.Subject == null)
         {
             return;
         }
-
-        // Even if using a custom subject format, it might still allow for regular SSNs or Organisation Numbers
-        // If not set to skip over that, then will first attempt to check for those as normal.
-        if (!skipRegularSubject)
-        {
-            var party = PartyParser.GetPartyFromIdentifier(_authRequest.Subject, out var error);
-            if (party == null && !customSubject)
-            {
-                throw new InvalidSubjectException($"Invalid subject supplied: {error}");
-            }
-            if (party != null)
-            {
-                _authRequest.Subject = party.NorwegianOrganizationNumber ?? party.NorwegianSocialSecurityNumber;
-                _authRequest.SubjectParty = party;
-                return;
-            }
-        }
-
-        // No SSN or Organisation Number found, or default validation is skipped.
-        // Moving on to custom subject format regex validation
-        if (string.IsNullOrEmpty(customSubjectRegex))
-        {
-            throw new EvidenceSourcePermanentServerException(5002, "Invalid custom subject regex for dataset");
-        }
         
-        var regexMatch = Regex.Match(_authRequest.Subject, customSubjectRegex);
-        if (!regexMatch.Success)
+        var party = PartyParser.GetPartyFromIdentifier(_authRequest.Subject, out var error);
+        if (party == null && !customSubject)
         {
-            throw new InvalidSubjectException("Invalid subject supplied: subject does not match custom subject format");
+            throw new InvalidSubjectException($"Invalid subject supplied: {error}");
         }
 
-        var subject = regexMatch.Groups[0].Value;
+        if (party != null)
+        {
+            _authRequest.Subject = party.NorwegianOrganizationNumber ?? party.NorwegianSocialSecurityNumber;
+            _authRequest.SubjectParty = party;
+            return;
+        }
+
+        // Custom Subject Validation will be done later in RequirementValidationService
         var customParty = new Party
         {
-            Id = subject
+            Id = _authRequest.Subject
         };
-        _authRequest.Subject = subject;
+        _authRequest.Subject = _authRequest.Subject;
         _authRequest.SubjectParty = customParty;
     }
 

--- a/Dan.Core/Services/AuthorizationRequestValidatorService.cs
+++ b/Dan.Core/Services/AuthorizationRequestValidatorService.cs
@@ -1,5 +1,7 @@
-﻿using Dan.Common;
+﻿using System.Text.RegularExpressions;
+using Dan.Common;
 using Dan.Common.Enums;
+using Dan.Common.Exceptions;
 using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Core.Config;
@@ -57,9 +59,34 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
         _authRequest = authorizationRequest ?? throw new InvalidAuthorizationRequestException();
         _registeredEvidenceCodes = await _availableEvidenceCodesService.GetAvailableEvidenceCodes();
         _evidenceCodesFromRequest = _registeredEvidenceCodes.Where(r => _authRequest.EvidenceRequests.Any(x => x.EvidenceCodeName == r.EvidenceCodeName)).ToList();
+        
+        var requirements = _evidenceCodesFromRequest.ToDictionary(es => es.EvidenceCodeName, es => es.AuthorizationRequirements);
+        if (authorizationRequest.FromEvidenceHarvester)
+        {
+            foreach (var requirement in requirements.Values)
+            {
+                requirement.RemoveAll(x => x.RequiredOnEvidenceHarvester == false);
+            }
+        }
 
+        var customSubject = false;
+        var customSubjectRegex = string.Empty;
+        var skipRegularSubjectValidation = false;
+        if (requirements.Values.SelectMany(x => x).Any(req =>
+                req.RequirementType is not null &&
+                req.RequirementType.Equals("CustomSubjectRequirement", StringComparison.InvariantCultureIgnoreCase)))
+        {
+            Console.WriteLine("Found custom subject req");
+            var requirement = requirements.Values.SelectMany(x => x).First(r => r.RequirementType is not null &&
+                                                                      r.RequirementType.Equals("CustomSubjectRequirement", StringComparison.InvariantCultureIgnoreCase));
+            var customSubjectRequirement = ((CustomSubjectRequirement)requirement);
+            customSubject = true;
+            customSubjectRegex = customSubjectRequirement.SubjectRegex;
+            skipRegularSubjectValidation = customSubjectRequirement.SkipRegularSubjectValidation;
+        }
+        
         ValidateAndPopulateRequestor();
-        ValidateAndPopulateSubject();
+        ValidateAndPopulateSubject(customSubject, skipRegularSubjectValidation, customSubjectRegex);
         ValidateLegalBasisWellFormed();
         ValidateEvidenceRequestWellFormed();
         ValidateEvidenceCodesAreAvailableForServiceContext();
@@ -77,15 +104,6 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
         }
 
         ValidateLanguageCodes();
-
-        var requirements = _evidenceCodesFromRequest.ToDictionary(es => es.EvidenceCodeName, es => es.AuthorizationRequirements);
-        if (authorizationRequest.FromEvidenceHarvester)
-        {
-            foreach (var requirement in requirements.Values)
-            {
-                requirement.RemoveAll(x => x.RequiredOnEvidenceHarvester == false);
-            }
-        }
 
         var authorizationErrors = await _requirementValidationService.ValidateRequirements(requirements, _authRequest);
         if (authorizationErrors.Count > 0)
@@ -185,7 +203,7 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
     /// Uses PartyParser on the supplied subject, and populates SubjectParty with it. Overwrites Requestor with norwegian identifier if applicable, else set to null
     /// </summary>
     /// <exception cref="InvalidSubjectException"></exception>
-    private void ValidateAndPopulateSubject()
+    private void ValidateAndPopulateSubject(bool customSubject, bool skipRegularSubject, string? customSubjectRegex = null)
     {
 
         if (_authRequest.Subject == null)
@@ -193,14 +211,43 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
             return;
         }
 
-        Party? party = PartyParser.GetPartyFromIdentifier(_authRequest.Subject, out string? error);
-        if (party == null)
+        // Even if using a custom subject format, it might still allow for regular SSNs or Organisation Numbers
+        // If not set to skip over that, then will first attempt to check for those as normal.
+        if (!skipRegularSubject)
         {
-            throw new InvalidSubjectException($"Invalid subject supplied: {error}");
+            var party = PartyParser.GetPartyFromIdentifier(_authRequest.Subject, out var error);
+            if (party == null && !customSubject)
+            {
+                throw new InvalidSubjectException($"Invalid subject supplied: {error}");
+            }
+            if (party != null)
+            {
+                _authRequest.Subject = party.NorwegianOrganizationNumber ?? party.NorwegianSocialSecurityNumber;
+                _authRequest.SubjectParty = party;
+                return;
+            }
         }
 
-        _authRequest.Subject = party.NorwegianOrganizationNumber ?? party.NorwegianSocialSecurityNumber;
-        _authRequest.SubjectParty = party;
+        // No SSN or Organisation Number found, or default validation is skipped.
+        // Moving on to custom subject format regex validation
+        if (string.IsNullOrEmpty(customSubjectRegex))
+        {
+            throw new EvidenceSourcePermanentServerException(5002, "Invalid custom subject regex for dataset");
+        }
+        
+        var regexMatch = Regex.Match(_authRequest.Subject, customSubjectRegex);
+        if (!regexMatch.Success)
+        {
+            throw new InvalidSubjectException("Invalid subject supplied: subject does not match custom subject format");
+        }
+
+        var subject = regexMatch.Groups[0].Value;
+        var customParty = new Party
+        {
+            Id = subject
+        };
+        _authRequest.Subject = subject;
+        _authRequest.SubjectParty = customParty;
     }
 
     private void ValidateLegalBasisWellFormed()

--- a/Dan.Core/Services/AuthorizationRequestValidatorService.cs
+++ b/Dan.Core/Services/AuthorizationRequestValidatorService.cs
@@ -1,8 +1,5 @@
-﻿using System.Text.RegularExpressions;
-using Dan.Common;
+﻿using Dan.Common;
 using Dan.Common.Enums;
-using Dan.Common.Exceptions;
-using Dan.Common.Interfaces;
 using Dan.Common.Models;
 using Dan.Core.Config;
 using Dan.Core.Exceptions;
@@ -217,7 +214,6 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
         {
             Id = _authRequest.Subject
         };
-        _authRequest.Subject = _authRequest.Subject;
         _authRequest.SubjectParty = customParty;
     }
 

--- a/Dan.Core/Services/RequirementValidationService.cs
+++ b/Dan.Core/Services/RequirementValidationService.cs
@@ -7,7 +7,6 @@ using Dan.Core.Services.Interfaces;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Text.RegularExpressions;
-using Dan.Common.Interfaces;
 
 namespace Dan.Core.Services;
 
@@ -592,14 +591,13 @@ public class RequirementValidationService : IRequirementValidationService
             return false;
         }
         
-        var regexMatch = Regex.Match(authRequest.Subject, req.SubjectRegex);
-        if (!regexMatch.Success)
+        var regexMatch = Regex.Match(authRequest.Subject, req.SubjectRegex, RegexOptions.None, TimeSpan.FromSeconds(1));
+        if (regexMatch.Success)
         {
-            AddError(req, $"Subject does not match custom subject format: {req.SubjectRegexDescription}", evidenceCodeName);
-            return false;
+            return true;
         }
-
-        return true;
+        AddError(req, $"Subject does not match custom subject format: {req.SubjectRegexDescription}", evidenceCodeName);
+        return false;
     }
 
     private async Task<PartyTypeConstraint> GetPartyType(string? identifier)

--- a/Dan.Core/Services/RequirementValidationService.cs
+++ b/Dan.Core/Services/RequirementValidationService.cs
@@ -107,6 +107,7 @@ public class RequirementValidationService : IRequirementValidationService
             AccreditationPartyRequirement r => ValidateAccreditationPartyRequirement(r, _authRequest.Subject, _authRequest.Requestor, _owner, evidenceCodeName),
             ReferenceRequirement r => ValidateReferenceRequirement(r, _authRequest, evidenceCodeName),
             ProvideOwnTokenRequirement r => ValidateProvideOwnTokenRequirement(r, evidenceCodeName),
+            CustomSubjectRequirement r => ValidateCustomSubjectRequirement(r, _authRequest, evidenceCodeName),
             _ => false
         };
 
@@ -567,6 +568,38 @@ public class RequirementValidationService : IRequirementValidationService
 
         AddError(req, $"The dataset {evidenceCodeName} requires that the client provides a bearer token or delegates access to Digitaliseringsdirektoratet", evidenceCodeName);
         return false;
+    }
+
+    private bool ValidateCustomSubjectRequirement(CustomSubjectRequirement req, AuthorizationRequest authRequest, string evidenceCodeName)
+    {
+        
+        if (authRequest.SubjectParty.Scheme is PartyParser.SchemeIso6523ActorIdUpis or 
+                                               PartyParser.SchemeNorwegianSsn or 
+                                               PartyParser.NorwegianIcd)
+        {
+            // Subject already parsed as Organisation number or norwegian ssn
+            return true;
+        }
+        if (string.IsNullOrWhiteSpace(authRequest.Subject))
+        {
+            AddError(req, $"Subject is missing", evidenceCodeName);
+            return false;
+        }
+        
+        if (string.IsNullOrEmpty(req.SubjectRegex))
+        {
+            AddError(req, $"Missing custom subject format regex", evidenceCodeName);
+            return false;
+        }
+        
+        var regexMatch = Regex.Match(authRequest.Subject, req.SubjectRegex);
+        if (!regexMatch.Success)
+        {
+            AddError(req, $"Subject does not match custom subject format: {req.SubjectRegexDescription}", evidenceCodeName);
+            return false;
+        }
+
+        return true;
     }
 
     private async Task<PartyTypeConstraint> GetPartyType(string? identifier)

--- a/Dan.PluginTest/Config/PluginConstants.cs
+++ b/Dan.PluginTest/Config/PluginConstants.cs
@@ -14,4 +14,5 @@ public static class PluginConstants
     public const string PluginForward = "PluginForward";
     public const string PluginSettingsTest = "PluginSettingsTest";
     public const string PluginGenericTest = "PluginGenericTest";
+    public const string PluginCustomSubjectTest = "PluginCustomSubjectTest";
 }

--- a/Dan.PluginTest/Metadata.cs
+++ b/Dan.PluginTest/Metadata.cs
@@ -109,6 +109,29 @@ public class Metadata : IEvidenceSourceMetadata
                     }
                 ]
             },
+            new EvidenceCode
+            {
+                EvidenceCodeName = PluginConstants.PluginCustomSubjectTest,
+                EvidenceSource = PluginConstants.Source,
+                BelongsToServiceContexts = _serviceContexts,
+                Values =
+                [
+                    new EvidenceValue
+                    {
+                        EvidenceValueName = "default",
+                        ValueType = EvidenceValueType.JsonSchema,
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<DatasetResponse>()
+                    }
+                ],
+                AuthorizationRequirements = 
+                [
+                    new CustomSubjectRequirement
+                    {
+                        SubjectRegex = @"^\d{1,8}$",
+                        SkipRegularSubjectValidation = false
+                    }
+                ]
+            },
         ];
     }
 }

--- a/Dan.PluginTest/Metadata.cs
+++ b/Dan.PluginTest/Metadata.cs
@@ -128,7 +128,7 @@ public class Metadata : IEvidenceSourceMetadata
                     new CustomSubjectRequirement
                     {
                         SubjectRegex = @"^\d{1,8}$",
-                        SkipRegularSubjectValidation = false
+                        SubjectRegexDescription = "A number 1-8 characters long"
                     }
                 ]
             },

--- a/Dan.PluginTest/Plugin.cs
+++ b/Dan.PluginTest/Plugin.cs
@@ -119,6 +119,31 @@ public class Plugin(
             () => EvidenceValuesPluginSettings(evidenceHarvesterRequest));
     }
     
+    [Function(PluginConstants.PluginCustomSubjectTest)]
+    public async Task<HttpResponseData> PluginCustomSubjectTest(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,
+        FunctionContext context)
+    {
+        EvidenceHarvesterRequest? evidenceHarvesterRequest;
+        try
+        {
+            evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e,
+                "Exception while attempting to parse request into EvidenceHarvesterRequest: {exceptionType}: {exceptionMessage}",
+                e.GetType().Name, e.Message);
+            throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput,
+                "Unable to parse request", e);
+        }
+
+        var unit = await ccrClientService.IsPublic("923609016", "local");
+        
+        return await EvidenceSourceResponse.CreateResponse(req,
+            () => GetEvidenceValuesDatasetOne(evidenceHarvesterRequest));
+    }
+    
     [Function(PluginConstants.PluginGenericTest)]
     public async Task<HttpResponseData> PluginGenericTest(
         [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequestData req,


### PR DESCRIPTION
### Description
In order to implement https://github.com/data-altinn-no/plugin-tilda/issues/76 we need to have proper support to say that a dataset supports subjects other than the typical Norwegian SSN or Organisation numbers. This feature will add a custom requirement for datasets that allows to specify a regex for what custom subject format should follow. Also adds a flag to say if it should skip the regular SSN/Orgnumber check first. If set to false, it will first check if subject is SSN or Org and set party values as normally before, but if not found or the flag is set to true, then core will only check the subject using the provided custom regex.

### Documentation
- [ ] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable "custom subject" requirement allowing regex-validated subject identifiers and fallback to minimal subject entries when using custom formats.
  * Added a new test plugin endpoint exposing an evidence code that enforces a digit-only subject pattern.

* **Tests**
  * Added comprehensive unit tests covering custom subject validation success and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->