### PR TITLE
fix(auth): validate JWT issuer against trusted allow-list

### DIFF
--- a/Dan.Core/Middleware/AuthenticationMiddleware.cs
+++ b/Dan.Core/Middleware/AuthenticationMiddleware.cs
@@ -9,6 +9,7 @@ using Dan.Core.Extensions;
 using Dan.Core.Helpers;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Middleware;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
@@ -26,6 +27,13 @@ public class AuthenticationMiddleware : IFunctionsWorkerMiddleware
     private static readonly object CmLockAltinnPlatform = new();
     private static volatile ConfigurationManager<OpenIdConnectConfiguration>? _cmMaskinporten;
     private static volatile ConfigurationManager<OpenIdConnectConfiguration>? _cmAltinnPlatform;
+
+    private readonly ILogger<AuthenticationMiddleware> _logger;
+
+    public AuthenticationMiddleware(ILogger<AuthenticationMiddleware> logger)
+    {
+        _logger = logger;
+    }
 
     /// <summary>
     /// Gets or sets maskinporten ConfigManager
@@ -141,36 +149,33 @@ public class AuthenticationMiddleware : IFunctionsWorkerMiddleware
         var tokenHandler = new JwtSecurityTokenHandler();
         var jwt = tokenHandler.ReadJwtToken(token);
 
-        // Load both trusted OIDC discovery documents. The authoritative issuer value
-        // each one advertises forms our explicit allow-list of accepted token issuers.
-        var maskinportenConfig = await CmMaskinporten.GetConfigurationAsync();
-        var altinnConfig = await CmAltinnPlatform.GetConfigurationAsync();
-        var validIssuers = new[] { maskinportenConfig.Issuer, altinnConfig.Issuer };
+        // Resolve the token against the trusted OIDC providers. Each discovery document is loaded
+        // independently and only the document advertising the token's own issuer is used, so the token
+        // can only ever be validated against the signing keys of its own issuer (no cross-issuer fallback).
+        var (discoveryDocument, discoveryUnavailable) = await ResolveIssuerConfiguration(jwt.Issuer);
 
-        // Select the signing keys belonging to the token's issuer. Reject any issuer
-        // that is not on the allow-list instead of silently falling back to Altinn,
-        // so a token can only ever be validated against the keys of its own issuer.
-        OpenIdConnectConfiguration discoveryDocument;
-        if (jwt.Issuer == maskinportenConfig.Issuer)
+        if (discoveryDocument == null)
         {
-            discoveryDocument = maskinportenConfig;
-        }
-        else if (jwt.Issuer == altinnConfig.Issuer)
-        {
-            discoveryDocument = altinnConfig;
-        }
-        else
-        {
-            throw new InvalidAccessTokenException($"Untrusted token issuer: '{jwt.Issuer}'");
-        }
+            if (discoveryUnavailable)
+            {
+                // The token's issuer did not match any provider we could reach, and at least one trusted
+                // discovery endpoint was unavailable - so we cannot determine whether the issuer is trusted.
+                // Surface this as a transient upstream failure (503) rather than rejecting a possibly-valid token.
+                throw new ServiceNotAvailableException(
+                    "Unable to verify the token issuer: a trusted identity provider's discovery endpoint is unavailable");
+            }
 
-        ICollection<SecurityKey> signingKeys = discoveryDocument.SigningKeys;
+            // All trusted discovery endpoints were reachable and none advertised this issuer. Do not echo the
+            // untrusted issuer value back to the caller; record it server-side for diagnostics instead.
+            _logger.LogWarning("Rejected access token from untrusted issuer '{issuer}'", jwt.Issuer);
+            throw new InvalidAccessTokenException("Untrusted token issuer");
+        }
 
         var validationParameters = new TokenValidationParameters
         {
-            IssuerSigningKeys = signingKeys,
+            IssuerSigningKeys = discoveryDocument.SigningKeys,
             ValidateIssuerSigningKey = true,
-            ValidIssuers = validIssuers,
+            ValidIssuers = new[] { discoveryDocument.Issuer },
             ValidateIssuer = true,
             ValidateAudience = false
         };
@@ -183,6 +188,53 @@ public class AuthenticationMiddleware : IFunctionsWorkerMiddleware
         {
             throw new InvalidAccessTokenException(e.GetType().Name + ": " + e.Message);
         }
+    }
+
+    /// <summary>
+    /// Resolves the trusted OIDC discovery document whose advertised issuer matches the token's issuer.
+    /// Each provider's discovery document is fetched independently so that an outage of one provider does
+    /// not prevent validation of tokens issued by the other.
+    /// </summary>
+    /// <param name="issuer">The (untrusted) issuer claimed by the token.</param>
+    /// <returns>
+    /// The matching discovery document, or <c>null</c> if no reachable provider advertised the issuer.
+    /// The boolean is <c>true</c> when at least one provider's discovery endpoint could not be reached,
+    /// meaning the allow-list could not be fully evaluated.
+    /// </returns>
+    private async Task<(OpenIdConnectConfiguration? Config, bool DiscoveryUnavailable)> ResolveIssuerConfiguration(string issuer)
+    {
+        var discoveryUnavailable = false;
+
+        var providers = new[]
+        {
+            ("Maskinporten", CmMaskinporten),
+            ("AltinnPlatform", CmAltinnPlatform)
+        };
+
+        foreach (var (providerName, configurationManager) in providers)
+        {
+            OpenIdConnectConfiguration config;
+            try
+            {
+                config = await configurationManager.GetConfigurationAsync();
+            }
+            catch (Exception ex)
+            {
+                // This provider's discovery endpoint is currently unreachable. Remember that the allow-list
+                // could not be fully evaluated, but keep checking other providers so a token from a reachable
+                // issuer still validates.
+                _logger.LogWarning(ex, "Failed to load OIDC discovery document for {provider}", providerName);
+                discoveryUnavailable = true;
+                continue;
+            }
+
+            if (config.Issuer == issuer)
+            {
+                return (config, false);
+            }
+        }
+
+        return (null, discoveryUnavailable);
     }
 
     private bool ValidateScopes(ClaimsPrincipal claimsPrincipal)

--- a/Dan.Core/Middleware/AuthenticationMiddleware.cs
+++ b/Dan.Core/Middleware/AuthenticationMiddleware.cs
@@ -141,14 +141,27 @@ public class AuthenticationMiddleware : IFunctionsWorkerMiddleware
         var tokenHandler = new JwtSecurityTokenHandler();
         var jwt = tokenHandler.ReadJwtToken(token);
 
+        // Load both trusted OIDC discovery documents. The authoritative issuer value
+        // each one advertises forms our explicit allow-list of accepted token issuers.
+        var maskinportenConfig = await CmMaskinporten.GetConfigurationAsync();
+        var altinnConfig = await CmAltinnPlatform.GetConfigurationAsync();
+        var validIssuers = new[] { maskinportenConfig.Issuer, altinnConfig.Issuer };
+
+        // Select the signing keys belonging to the token's issuer. Reject any issuer
+        // that is not on the allow-list instead of silently falling back to Altinn,
+        // so a token can only ever be validated against the keys of its own issuer.
         OpenIdConnectConfiguration discoveryDocument;
-        if (jwt.Issuer == Settings.MaskinportenUrl)
+        if (jwt.Issuer == maskinportenConfig.Issuer)
         {
-            discoveryDocument = await CmMaskinporten.GetConfigurationAsync();
+            discoveryDocument = maskinportenConfig;
+        }
+        else if (jwt.Issuer == altinnConfig.Issuer)
+        {
+            discoveryDocument = altinnConfig;
         }
         else
         {
-            discoveryDocument = await CmAltinnPlatform.GetConfigurationAsync();
+            throw new InvalidAccessTokenException($"Untrusted token issuer: '{jwt.Issuer}'");
         }
 
         ICollection<SecurityKey> signingKeys = discoveryDocument.SigningKeys;
@@ -157,8 +170,9 @@ public class AuthenticationMiddleware : IFunctionsWorkerMiddleware
         {
             IssuerSigningKeys = signingKeys,
             ValidateIssuerSigningKey = true,
-            ValidateAudience = false,
-            ValidateIssuer = false
+            ValidIssuers = validIssuers,
+            ValidateIssuer = true,
+            ValidateAudience = false
         };
 
         try


### PR DESCRIPTION
## Summary

Hardens JWT authentication in `AuthenticationMiddleware.ValidateJwt`. Previously the issuer was **not** validated (`ValidateIssuer = false`) and the signing-key set was chosen with a silent `else` fallback to Altinn Platform for any non-Maskinporten issuer:

```csharp
if (jwt.Issuer == Settings.MaskinportenUrl)
    discoveryDocument = await CmMaskinporten.GetConfigurationAsync();
else
    discoveryDocument = await CmAltinnPlatform.GetConfigurationAsync(); // catch-all
```

This effectively merged the Maskinporten and Altinn Platform trust domains into one key pool: a token from any issuer was accepted as long as it was signed by the Altinn Platform keys, and nothing asserted the `iss` claim.

## Changes

- Build an explicit issuer allow-list from the authoritative `Issuer` value of each trusted OIDC discovery document (Maskinporten + Altinn Platform).
- Select signing keys **per-issuer**; an unknown issuer is rejected with `InvalidAccessTokenException` instead of falling back.
- Enable `ValidateIssuer = true` with `ValidIssuers` set to the allow-list.

The allow-list is derived from each discovery document's `Issuer` (not hardcoded) so it stays correct across environments (test vs prod Maskinporten, tt02 vs prod Altinn).

## Why audience is intentionally still not validated

DAN owns the `dan` and `altinn:dataaltinnno` scope prefixes. The scope namespace is closed, so a token carrying one of those scopes means DAN registered and granted it — scope possession *is* the authorization decision. No other API can be the audience for a scope in a namespace DAN owns, so `aud` validation adds no guarantee scope ownership doesn't already provide. `ValidateAudience` is left `false` deliberately.

## Testing

- `dotnet build Dan.Core` succeeds (0 errors; pre-existing warnings only).
- No existing unit tests reference this middleware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened token validation by implementing stricter issuer verification against trusted authorities, ensuring only properly authorized tokens are accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->