### PR TITLE
fix(consent): live consent gate on harvest + stop logging secrets

### DIFF
--- a/Dan.Core/Services/AuthorizationRequestValidatorService.cs
+++ b/Dan.Core/Services/AuthorizationRequestValidatorService.cs
@@ -355,8 +355,8 @@ public class AuthorizationRequestValidatorService : IAuthorizationRequestValidat
 
             if (!registeredEvidenceCode.IsValidServiceContext(_requestContextService.ServiceContext))
             {
-                _log.LogWarning("Request for '{evidenceCode}' from '{authenticatedOrg}' with subscription key '{subscriptionKey}' for product '{productid}', expected one of: {availableForProducts}",
-                    registeredEvidenceCode.EvidenceCodeName, _requestContextService.AuthenticatedOrgNumber, _requestContextService.SubscriptionKey, _requestContextService.ServiceContext.Name, string.Join(", ", registeredEvidenceCode.GetBelongsToServiceContexts()));
+                _log.LogWarning("Request for '{evidenceCode}' from '{authenticatedOrg}' for product '{productid}', expected one of: {availableForProducts}",
+                    registeredEvidenceCode.EvidenceCodeName, _requestContextService.AuthenticatedOrgNumber, _requestContextService.ServiceContext.Name, string.Join(", ", registeredEvidenceCode.GetBelongsToServiceContexts()));
 
                 throw new InvalidEvidenceRequestException(
                     $"The evidence code: {evidenceRequest.EvidenceCodeName} is not available for the supplied subscription key product '{_requestContextService.ServiceContext.Name}', expected one of: {string.Join(", ", registeredEvidenceCode.GetBelongsToServiceContexts())}.");

--- a/Dan.Core/Services/ConsentService.cs
+++ b/Dan.Core/Services/ConsentService.cs
@@ -200,12 +200,12 @@ public class ConsentService : IConsentService
         request.Headers.TryAddWithoutValidation("ApiKey", Settings.AltinnApiKey);
         request.Headers.TryAddWithoutValidation("Accept", "application/json");
         request.SetAllowedErrorCodes(HttpStatusCode.BadRequest, HttpStatusCode.Forbidden);
-        _logger.LogInformation("Getting jwt: " + url);
+        _logger.LogInformation("Getting consent jwt from Altinn");
         try
         {
             var result = await _noCertHttpClient.SendAsync(request);
 
-            _logger.LogInformation($"JWT-get {result.RequestMessage} result: {result.StatusCode} : {result.ReasonPhrase}");
+            _logger.LogInformation("JWT-get result: {statusCode} : {reasonPhrase}", result.StatusCode, result.ReasonPhrase);
 
             // Altinn returns JWTs as bare JSON strings (with leading and trailing double quotes) 
             var jwt = await result.Content.ReadAsStringAsync();

--- a/Dan.Core/Services/EvidenceHarvesterService.cs
+++ b/Dan.Core/Services/EvidenceHarvesterService.cs
@@ -42,7 +42,10 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         var evidenceCode = accreditation.GetValidEvidenceCode(evidenceCodeName);
 
         _log.LogInformation("Start get evidence status | aid={accreditationId}, evidenceCode={evidenceCodeName}", accreditation.AccreditationId, evidenceCode.EvidenceCodeName);
-        var evidenceStatus = await _evidenceStatusService.GetEvidenceStatusAsync(accreditation, evidenceCode, onlyLocalChecks:true);
+        // Use a live (non-local) consent/status check here: this is the actual data-release gate,
+        // so we must not rely on locally cached consent state that may have been revoked or expired
+        // upstream since it was stored. This matches HarvestStream below.
+        var evidenceStatus = await _evidenceStatusService.GetEvidenceStatusAsync(accreditation, evidenceCode, onlyLocalChecks:false);
 
         ThrowIfNotAvailableForHarvest(evidenceStatus);
 
@@ -273,8 +276,8 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
 
             var token = await _tokenRequesterService.GetMaskinportenToken(evidenceCode.RequiredScopes, GetConsumerOrg(accreditation, evidenceHarvesterOptions));
 
-            _log.LogInformation("Completed getting mp-token | aid={accreditationId}, token={token}",
-                accreditation.AccreditationId, token);
+            _log.LogInformation("Completed getting mp-token | aid={accreditationId}",
+                accreditation.AccreditationId);
 
             if (string.IsNullOrEmpty(token))
             {
@@ -303,15 +306,14 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         using (var _ = _log.Timer("jwt-fetch"))
         {
             _log.LogInformation(
-                "Getting JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}, authCode={authorizationCode}",
-                accreditation.AccreditationId, evidenceCode.EvidenceCodeName, accreditation.AuthorizationCode);            
+                "Getting JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}",
+                accreditation.AccreditationId, evidenceCode.EvidenceCodeName);
 
             string jwt = await _a3ConsentService.GetJwt(accreditation, evidenceCode);
             var response = JsonConvert.DeserializeObject<Dictionary<string, string>>(jwt);
             _log.LogInformation(
-                "Completed JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}, authCode={authorizationCode}, jwt={jwt}",
-                accreditation.AccreditationId, evidenceCode.EvidenceCodeName, accreditation.AuthorizationCode,
-                jwt);
+                "Completed JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}",
+                accreditation.AccreditationId, evidenceCode.EvidenceCodeName);
 
             return jwt;
         }
@@ -322,16 +324,16 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         using (var _ = _log.Timer("jwt-fetch"))
         {
             _log.LogInformation(
-                "Getting JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}, authCode={authorizationCode}, a3consentid={a3consentid}",
-                accreditation.AccreditationId, evidenceCode.EvidenceCodeName, accreditation.AuthorizationCode, accreditation.Altinn3ConsentId);
+                "Getting JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}, a3consentid={a3consentid}",
+                accreditation.AccreditationId, evidenceCode.EvidenceCodeName, accreditation.Altinn3ConsentId);
 
             string response = await _a3ConsentService.GetJwt(accreditation, evidenceCode);
             var jwt = JsonConvert.DeserializeObject<Dictionary<string, string>>(response);
 
             if (jwt?["access_token"] == null)
                 _log.LogInformation(
-                "Completed JWT | aid={accreditationId}, evidenceCode={evidenceCodeName}, authCode={authorizationCode}, jwt={jwt}",
-                accreditation.AccreditationId, evidenceCode.EvidenceCodeName, accreditation.AuthorizationCode, jwt);
+                "Completed JWT, but no access_token in response | aid={accreditationId}, evidenceCode={evidenceCodeName}",
+                accreditation.AccreditationId, evidenceCode.EvidenceCodeName);
 
             return jwt["access_token"];
         }


### PR DESCRIPTION
Addresses two findings from the security review.

## #6 — Stale/revoked consent honored on the main harvest path (TOCTOU)

`EvidenceHarvesterService.Harvest` ran its consent/status gate with `onlyLocalChecks: true`, which decides from locally cached consent state (`AuthorizationCode` / `Altinn3ConsentStatus` / `ValidTo`) and **skips the live Altinn/Maskinporten check**. A consent that the subject revoked (or that expired) upstream *after* it was stored was therefore still treated as granted on the primary JSON harvest path, and the data was released.

`HarvestStream` already used `onlyLocalChecks: false`. This change makes `Harvest` consistent so the actual data-release gate is always a live check.

```diff
-var evidenceStatus = await _evidenceStatusService.GetEvidenceStatusAsync(accreditation, evidenceCode, onlyLocalChecks:true);
+var evidenceStatus = await _evidenceStatusService.GetEvidenceStatusAsync(accreditation, evidenceCode, onlyLocalChecks:false);
```

**Behavioral note for reviewers:** with `onlyLocalChecks: false`, asynchronous non-consent evidence codes now also do a live status call to the evidence source before harvest (returning `Waiting`/`AsyncEvidenceStillWaiting` if not ready) instead of proceeding directly. This matches the existing `HarvestStream` behavior and is the intended async semantics, but it is a behavior change for async codes on the JSON path — worth a sanity check against your async sources.

## #7 — Bearer tokens / consent JWTs / auth codes / subscription keys in logs

Removed replayable credentials from log statements (they were emitted at Information/Warning level and shipped to App Insights):

- Full Maskinporten access token — `EvidenceHarvesterService.GetAccessToken`
- Consent JWTs and consent authorization codes — `GetConsentToken` / `GetMaskinportenConsentToken`
- Request URL embedding the consent authorization code — `ConsentService.GetJwt`
- APIM subscription key — `AuthorizationRequestValidatorService`

Diagnostic context that is not secret (accreditation id, evidence code, a3 consent id, status/reason) is retained.

## Testing

- `dotnet build Dan.Core` — 0 errors.
- `EvidenceHarvesterServiceTest`, `EvidenceStatusServiceTest`, `ConsentServiceTest` pass (run via Microsoft.Testing.Platform; the existing mocks match `onlyLocalChecks` with any-bool, so the gate change is covered without breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)