### PR TITLE
fix(deps): pin transitive packages to patched versions for High-severity advisories

### DIFF
--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -61,13 +61,20 @@
     <PackageReference Include="Polly" Version="8.6.5" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
     
-    <!-- WCF related things --> 
+    <!-- WCF related things -->
     <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
     <PackageReference Include="System.ServiceModel.Http" Version="10.0.652802" />
     <PackageReference Include="System.ServiceModel.NetTcp" Version="10.0.652802" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="10.0.652802" />
     <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
+
+    <!-- Transitive pins to patched versions to resolve known High-severity advisories.
+         Remove once the parent packages reference patched versions directly.
+         Snappier (via Parquet.Net): GHSA-pggp-6c3x-2xmx, fixed in 1.3.1
+         System.Security.Cryptography.Xml (via System.ServiceModel.*): GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (CVE-2026-33116), fixed in 10.0.6 -->
+    <PackageReference Include="Snappier" Version="1.3.1" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
 
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

`dotnet list package --vulnerable --include-transitive` flagged two **transitive** packages with known **High-severity** advisories. Both are reachable from `Dan.Core` (and inherited by `Dan.Core.UnitTest` via project reference).

| Package | Resolved | Pulled in by | Advisory | Fixed in |
|---|---|---|---|---|
| Snappier | 1.3.0 | `Parquet.Net 5.5.0` | [GHSA-pggp-6c3x-2xmx](https://github.com/advisories/GHSA-pggp-6c3x-2xmx) — infinite loop / DoS on malformed framed Snappy data | **1.3.1** |
| System.Security.Cryptography.Xml | 10.0.0 | `System.ServiceModel.*` (WCF stack) | [GHSA-37gx-xxp4-5rgx](https://github.com/advisories/GHSA-37gx-xxp4-5rgx) / [GHSA-w3x6-4m5h-cxqf](https://github.com/advisories/GHSA-w3x6-4m5h-cxqf) (CVE-2026-33116) — infinite loop / DoS in `EncryptedXml` | **10.0.6** (.NET 10 line) |

## Fix

Added direct transitive-pin `PackageReference`s to `Dan.Core.csproj`. A direct reference overrides the transitive version, forcing the patched build without touching the parent packages:

```xml
<PackageReference Include="Snappier" Version="1.3.1" />
<PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
```

- Snappier 1.3.1 is the minimal patched release (vs. a risky `Parquet.Net` 5→6 major bump).
- Crypto.Xml is pinned to 10.0.9 (latest stable in the 10.0 line; ≥ the 10.0.6 fix).
- A comment documents why the pins exist and that they can be removed once the parents reference patched versions.

## Verification

- `dotnet list Dan.sln package --vulnerable --include-transitive` → **no vulnerable packages** in any project.
- `dotnet build Dan.sln` → 0 errors, no NU1903 warnings.
- `Dan.Core.UnitTest` full suite passes (run via Microsoft.Testing.Platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)