### PR TITLE
fix(privacy): prevent future logging full national identity number for person subjects

### DIFF
--- a/Dan.Core/Services/Altinn3ConsentService.cs
+++ b/Dan.Core/Services/Altinn3ConsentService.cs
@@ -406,7 +406,10 @@ namespace Dan.Core.Services
             request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {token["access_token"]}");
             request.JsonContent(consentRequest);
 
-            _logger.LogInformation(JsonConvert.SerializeObject(consentRequest));
+            // Do not log the serialized consent request: its From/To fields contain the
+            // subject's full national identity number (urn:altinn:person:identifier-no:<fnr>).
+            _logger.LogInformation("Created Altinn3 consent request consentRequestId={consentRequestId} aid={accreditationId}",
+                consentRequest.Id, accreditation.AccreditationId);
 
             try
             {
@@ -425,8 +428,9 @@ namespace Dan.Core.Services
                         }
                     }
 
-                    _logger.LogError("Failed to create consent request for AccreditationId={accreditationId}, Subject={subject}, StatusCode={statusCode}, ReasonPhrase={reasonPhrase}, ConsentErrors={consentErrors}, RequestJson={requestJson}",
-                        accreditation.AccreditationId, accreditation.SubjectParty, response.StatusCode, response.ReasonPhrase, errorString, request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync());
+                    // RequestJson is intentionally omitted: the request body contains the subject's full national identity number.
+                    _logger.LogError("Failed to create consent request for AccreditationId={accreditationId}, Subject={subject}, StatusCode={statusCode}, ReasonPhrase={reasonPhrase}, ConsentErrors={consentErrors}",
+                        accreditation.AccreditationId, accreditation.SubjectParty, response.StatusCode, response.ReasonPhrase, errorString);
                     throw new ServiceNotAvailableException("Altinn denied the consent request. This is an internal error, please contact support");
                 }
 

--- a/Dan.Core/Services/ConsentService.cs
+++ b/Dan.Core/Services/ConsentService.cs
@@ -277,7 +277,9 @@ public class ConsentService : IConsentService
         }
         catch (Exception ex)
         {
-            _logger.LogError($"Failed to  log consent used (Altinn) for AccreditationId={accreditation.AccreditationId}, Subject={accreditation.Subject}:\n{ex}");
+            // Use the masked SubjectParty, not the raw accreditation.Subject (which is the subject's full national identity number for persons).
+            _logger.LogError(ex, "Failed to log consent used (Altinn) for AccreditationId={accreditationId}, Subject={subject}",
+                accreditation.AccreditationId, accreditation.SubjectParty);
             return false;
         }
     }
@@ -382,8 +384,9 @@ public class ConsentService : IConsentService
                     }
                 }
 
-                _logger.LogError("Failed to create consent request for AccreditationId={accreditationId}, Subject={subject}, StatusCode={statusCode}, ReasonPhrase={reasonPhrase}, ConsentErrors={consentErrors}, RequestJson={requestJson}",
-                    accreditation.AccreditationId, accreditation.SubjectParty, response.StatusCode, response.ReasonPhrase, errorString, request.Content == null ? string.Empty : await request.Content.ReadAsStringAsync());
+                // RequestJson is intentionally omitted: the request body's OfferedBy is the subject's full national identity number.
+                _logger.LogError("Failed to create consent request for AccreditationId={accreditationId}, Subject={subject}, StatusCode={statusCode}, ReasonPhrase={reasonPhrase}, ConsentErrors={consentErrors}",
+                    accreditation.AccreditationId, accreditation.SubjectParty, response.StatusCode, response.ReasonPhrase, errorString);
                 throw new ServiceNotAvailableException("Altinn denied the consent request. This is an internal error, please contact support");
             }
 


### PR DESCRIPTION
## Summary

To get ahead of future services when not only organisations give consent: 
For **person** subjects, `accreditation.Subject` is the full 11-digit Norwegian national identity number (fødselsnummer), and `SubjectParty.GetAltinnFormat()` embeds it as `urn:altinn:person:identifier-no:<fnr>`. `Party.GetAsString()` / `ToString()` masks it (`DDMMYY` + `*****`), but four log sites bypassed that masking and wrote the **full** number to the logs (App Insights).

## Fixes

| File:line (before) | Problem | Fix |
|---|---|---|
| `Altinn3ConsentService.cs:409` | `LogInformation(JsonConvert.SerializeObject(consentRequest))` — full request incl. `From` = person URN, **Information level, on every A3 consent creation** | Replaced with a non-PII breadcrumb (`consentRequestId` + `accreditationId`) |
| `Altinn3ConsentService.cs:428` | `RequestJson={...}` error log dumped the full request body (`From` = full fnr) | Dropped the `RequestJson` argument; kept `Subject` (masked Party), status, reason, errors |
| `ConsentService.cs:385` | `RequestJson={...}` error log dumped the full request body (`OfferedBy` = full fnr) | Dropped the `RequestJson` argument |
| `ConsentService.cs:280` | logged the raw `accreditation.Subject` (full fnr) | Switched to the masked `SubjectParty` (and use the `LogError(ex, ...)` overload) |

The `Subject={subject}` fields already passed the `Party` object (masked via `ToString()`) and were fine — only the raw-string and full-body companions leaked.

## Notes / out of scope

- Logging a `Party` as `{subject}` (non-destructured) relies on `ToString()` masking. Switching any of these to destructured `{@subject}` would re-expose `NorwegianSocialSecurityNumber` as a raw property — worth keeping in mind.
- `AuthorizationRequestValidatorService.cs` interpolates `_authRequest.Subject` into exception messages, but that path is gated to **org-number** subjects, so it is not a person-fnr leak.

## Testing

- `dotnet build Dan.Core` — 0 errors.
- `ConsentServiceTest` and `A3ConsentServiceTest` pass (run via Microsoft.Testing.Platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)