### PR TITLE
feat(notifications): send consent reminders via Altinn 3 Notifications API

### DIFF
--- a/Dan.Common/Constants.cs
+++ b/Dan.Common/Constants.cs
@@ -17,6 +17,8 @@ public static class Constants
     
     public const string PluginHttpClient = "PluginHttpClient";
 
+    public const string Altinn3NotificationsHttpClient = "Altinn3NotificationsHttpClient";
+
     public const string LANGUAGE_CODE_NORWEGIAN_NB = "no-nb";
 
     public const string LANGUAGE_CODE_NORWEGIAN_NN = "no-nn";

--- a/Dan.Core.UnitTest/Altinn3NotificationsServiceTest.cs
+++ b/Dan.Core.UnitTest/Altinn3NotificationsServiceTest.cs
@@ -1,0 +1,226 @@
+using Dan.Common;
+using Dan.Common.Models;
+using Dan.Core.Models.Notifications;
+using Dan.Core.ServiceContextTexts;
+using Dan.Core.Services;
+using Dan.Core.Services.Interfaces;
+using Dan.Core.UnitTest.Helpers;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+
+namespace Dan.Core.UnitTest
+{
+    [TestClass]
+    [ExcludeFromCodeCoverage]
+    public class Altinn3NotificationsServiceTest
+    {
+        private readonly IHttpClientFactory _mockHttpClientFactory = A.Fake<IHttpClientFactory>();
+        private readonly ITokenRequesterService _mockTokenRequesterService = A.Fake<ITokenRequesterService>();
+        private readonly IEntityRegistryService _mockEntityRegistryService = A.Fake<IEntityRegistryService>();
+        private readonly ILogger<Altinn3NotificationsService> _mockLogger = A.Fake<ILogger<Altinn3NotificationsService>>();
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            A.CallTo(() => _mockTokenRequesterService.GetAltinnExchangedToken(A<string>._, A<string>._))
+                .Returns(Task.FromResult("{\"access_token\":\"test-token\"}"));
+
+            A.CallTo(() => _mockEntityRegistryService.Get(A<string>._))
+                .Returns(Task.FromResult(new SimpleEntityRegistryUnit { Name = "Test Organization" }));
+        }
+
+        [TestMethod]
+        public async Task SendReminder_OrganizationSubject_PostsEmailAndSmsOrder_ReturnsSentReceipts()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            string? capturedBody = null;
+            var orderId = Guid.NewGuid();
+
+            var httpClient = TestHelpers.GetHttpClientMock(request =>
+            {
+                capturedRequest = request;
+                capturedBody = request.Content?.ReadAsStringAsync().Result;
+                return new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent($"{{\"notificationOrderId\":\"{orderId}\",\"notification\":{{\"shipmentId\":\"{Guid.NewGuid()}\"}}}}")
+                };
+            });
+            A.CallTo(() => _mockHttpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient)).Returns(httpClient);
+
+            var service = CreateService();
+            var accreditation = GetAccreditation();
+
+            // Act
+            var result = await service.SendReminder(accreditation, GetServiceContext());
+
+            // Assert: two receipts, both sent
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.All(r => r.Success));
+            CollectionAssert.AreEquivalent(new[] { "Email", "SMS" }, result.Select(r => r.NotificationType).ToList());
+
+            // Assert: posted to the future/orders endpoint with a bearer token
+            Assert.IsNotNull(capturedRequest);
+            Assert.AreEqual(HttpMethod.Post, capturedRequest!.Method);
+            StringAssert.EndsWith(capturedRequest.RequestUri!.AbsoluteUri, "/notifications/api/v1/future/orders");
+            Assert.AreEqual("Bearer test-token", capturedRequest.GetHeader("Authorization"));
+
+            // Assert: request body targets the organization with EmailAndSms and rendered content
+            var order = JsonConvert.DeserializeObject<NotificationOrderChainRequest>(capturedBody!);
+            Assert.IsNotNull(order);
+            Assert.AreEqual(accreditation.AccreditationId, order!.SendersReference);
+            Assert.IsNotNull(order.Recipient.RecipientOrganization);
+            Assert.IsNull(order.Recipient.RecipientPerson);
+            Assert.AreEqual("910402021", order.Recipient.RecipientOrganization!.OrgNumber);
+            Assert.AreEqual(NotificationChannel.EmailAndSms, order.Recipient.RecipientOrganization.ChannelSchema);
+            Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.EmailSettings!.Subject));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.EmailSettings.Body));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.SmsSettings!.Body));
+        }
+
+        [TestMethod]
+        public async Task SendReminder_PersonSubject_UsesRecipientPerson()
+        {
+            // Arrange
+            string? capturedBody = null;
+            var httpClient = TestHelpers.GetHttpClientMock(request =>
+            {
+                capturedBody = request.Content?.ReadAsStringAsync().Result;
+                return new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent($"{{\"notificationOrderId\":\"{Guid.NewGuid()}\"}}")
+                };
+            });
+            A.CallTo(() => _mockHttpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient)).Returns(httpClient);
+
+            var service = CreateService();
+            var accreditation = GetAccreditation();
+            accreditation.SubjectParty = new Party { NorwegianSocialSecurityNumber = "08075412345" };
+
+            // Act
+            var result = await service.SendReminder(accreditation, GetServiceContext());
+
+            // Assert
+            Assert.IsTrue(result.All(r => r.Success));
+            var order = JsonConvert.DeserializeObject<NotificationOrderChainRequest>(capturedBody!);
+            Assert.IsNotNull(order!.Recipient.RecipientPerson);
+            Assert.IsNull(order.Recipient.RecipientOrganization);
+            Assert.AreEqual("08075412345", order.Recipient.RecipientPerson!.NationalIdentityNumber);
+            Assert.AreEqual(NotificationChannel.EmailAndSms, order.Recipient.RecipientPerson.ChannelSchema);
+        }
+
+        [TestMethod]
+        public async Task SendReminder_ApiFailure_ReturnsFailedReceipts()
+        {
+            // Arrange
+            var httpClient = TestHelpers.GetHttpClientMock(_ =>
+                new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("boom") });
+            A.CallTo(() => _mockHttpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient)).Returns(httpClient);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.SendReminder(GetAccreditation(), GetServiceContext());
+
+            // Assert
+            Assert.AreEqual(2, result.Count);
+            Assert.IsTrue(result.All(r => !r.Success));
+            Assert.IsTrue(result.All(r => r.RecipientCount == 0));
+        }
+
+        [TestMethod]
+        public async Task GetOrderStatus_NotFound_ReturnsNull()
+        {
+            // Arrange
+            var httpClient = TestHelpers.GetHttpClientMock(_ =>
+                new HttpResponseMessage(HttpStatusCode.NotFound) { Content = new StringContent("") });
+            A.CallTo(() => _mockHttpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient)).Returns(httpClient);
+
+            var service = CreateService();
+
+            // Act
+            var result = await service.GetOrderStatus(Guid.NewGuid());
+
+            // Assert
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        public async Task CreateInstantSmsOrder_PostsToInstantSmsEndpoint()
+        {
+            // Arrange
+            HttpRequestMessage? capturedRequest = null;
+            var httpClient = TestHelpers.GetHttpClientMock(request =>
+            {
+                capturedRequest = request;
+                return new HttpResponseMessage(HttpStatusCode.Created)
+                {
+                    Content = new StringContent($"{{\"notificationOrderId\":\"{Guid.NewGuid()}\"}}")
+                };
+            });
+            A.CallTo(() => _mockHttpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient)).Returns(httpClient);
+
+            var service = CreateService();
+            var order = new InstantSmsNotificationOrderRequest
+            {
+                IdempotencyId = Guid.NewGuid().ToString(),
+                RecipientSms = new ShortMessageDeliveryDetails
+                {
+                    PhoneNumber = "+4799999999",
+                    TimeToLiveInSeconds = 3600,
+                    ShortMessageContent = new ShortMessageContent { Body = "hi" }
+                }
+            };
+
+            // Act
+            await service.CreateInstantSmsOrder(order);
+
+            // Assert
+            Assert.IsNotNull(capturedRequest);
+            StringAssert.EndsWith(capturedRequest!.RequestUri!.AbsoluteUri, "/notifications/api/v1/future/orders/instant/sms");
+        }
+
+        private Altinn3NotificationsService CreateService()
+        {
+            return new Altinn3NotificationsService(
+                _mockHttpClientFactory,
+                _mockTokenRequesterService,
+                _mockEntityRegistryService,
+                _mockLogger);
+        }
+
+        private static ServiceContext GetServiceContext()
+        {
+            return new ServiceContext
+            {
+                Id = "ebevis-product",
+                Name = "eBevis",
+                ValidLanguages = new List<string> { Constants.LANGUAGE_CODE_NORWEGIAN_NB },
+                AuthorizationRequirements = new List<Requirement>(),
+                ServiceContextTextTemplate = new EBevisServiceContextTextTemplate()
+            };
+        }
+
+        private static Accreditation GetAccreditation()
+        {
+            return new Accreditation
+            {
+                AccreditationId = Guid.NewGuid().ToString(),
+                Subject = "910402021",
+                Requestor = "958935420",
+                SubjectParty = new Party { NorwegianOrganizationNumber = "910402021" },
+                RequestorParty = new Party { NorwegianOrganizationNumber = "958935420" },
+                AuthorizationCode = "",
+                ValidTo = DateTime.Now.AddDays(1),
+                ConsentReference = "2019-2312",
+                ExternalReference = "externalreference",
+                LanguageCode = Constants.LANGUAGE_CODE_NORWEGIAN_NB,
+                EvidenceCodes = new List<EvidenceCode>()
+            };
+        }
+    }
+}

--- a/Dan.Core.UnitTest/appsettings.unittest.json
+++ b/Dan.Core.UnitTest/appsettings.unittest.json
@@ -11,6 +11,8 @@
   "ConsentValidationSecrets": "test-secret-key-for-unit-tests",
   "ConsentRedirectURLPattern": "https://test.altinn.no/consent/{0}?hmac={1}",
   "Altinn3ConsentUrl": "https://test.altinn.no/api/consent",
+  "NotificationsApiBaseUrl": "https://test.altinn.no/notifications/api/v1",
+  "AltinnTokenExchangeUrl": "https://test.altinn.no/authentication/api/v1/exchange/maskinporten",
   "DoffinLinkTemplate": "{0}",
   "EvidenceSources": "ut1",
   "EvidenceSourceURLPattern": "http://%s.unittest.net/api/evidencecodes,",

--- a/Dan.Core/Config/Settings.cs
+++ b/Dan.Core/Config/Settings.cs
@@ -390,6 +390,22 @@ public static class Settings
 
     public static string Altinn3ConsentUrl => GetSetting("Altinn3ConsentUrl");
 
+    /// <summary>
+    /// Base URL of the Altinn 3 Notifications API, e.g. https://platform.tt02.altinn.no/notifications/api/v1
+    /// </summary>
+    public static string NotificationsApiBaseUrl => GetSetting("NotificationsApiBaseUrl");
+
+    /// <summary>
+    /// Maskinporten scope used when creating notification orders, e.g. altinn:serviceowner/notifications.create
+    /// </summary>
+    public static string NotificationsCreateScope => "altinn:serviceowner/notifications.create";
+
+    /// <summary>
+    /// Altinn endpoint for exchanging a Maskinporten token for an Altinn token,
+    /// e.g. https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten
+    /// </summary>
+    public static string AltinnTokenExchangeUrl => GetSetting("AltinnTokenExchangeUrl");
+
     private static string GetSetting(string settingKey)
     {
         var value = ConfigurationHelper.ConfigurationRoot[settingKey];

--- a/Dan.Core/FuncConsentReminder.cs
+++ b/Dan.Core/FuncConsentReminder.cs
@@ -15,22 +15,22 @@ namespace Dan.Core
     /// </summary>
     public class FuncConsentReminder
     {
-        private readonly IAltinnCorrespondenceService _altinnCorrespondenceService;
-        private readonly IConsentService _consentService;
+        private readonly IAltinn3NotificationsService _altinn3NotificationsService;
+        private readonly IAltinn3ConsentService _consentService;
         private readonly IEvidenceStatusService _evidenceStatusService;
         private readonly IRequestContextService _requestContextService;
         private readonly IAccreditationRepository _applicationRepository;
         private readonly ILogger<FuncConsentReminder> _logger;
 
         public FuncConsentReminder(
-            IAltinnCorrespondenceService altinnCorrespondenceService,
-            IConsentService consentService,
+            IAltinn3NotificationsService altinn3NotificationsService,
+            IAltinn3ConsentService consentService,
             IEvidenceStatusService evidenceStatusService,
             IRequestContextService requestContextService,
             IAccreditationRepository applicationRepository,
             ILoggerFactory loggerFactory)
-        {            
-            _altinnCorrespondenceService = altinnCorrespondenceService;
+        {
+            _altinn3NotificationsService = altinn3NotificationsService;
             _consentService = consentService;
             _evidenceStatusService = evidenceStatusService;
             _requestContextService = requestContextService;
@@ -68,7 +68,7 @@ namespace Dan.Core
 
             await ValidateAccreditationForReminder(accreditationId, accreditation);
 
-            var response = await _altinnCorrespondenceService.SendNotification(accreditation, _requestContextService.ServiceContext);
+            var response = await _altinn3NotificationsService.SendReminder(accreditation, _requestContextService.ServiceContext);
             accreditation.Reminders.AddRange(response);
 
             await _applicationRepository.UpdateAccreditationAsync(accreditation);
@@ -92,7 +92,7 @@ namespace Dan.Core
             if (accr.ValidTo < DateTime.Now)
                 throw new ExpiredConsentException("The consent for this accreditation is expired");
 
-            var lastReminderSent = accr.Reminders.MaxBy(x => x.Date);
+            var lastReminderSent = accr.Reminders.Where(x => x.Success).MaxBy(x => x.Date);
             if (lastReminderSent != null && lastReminderSent.Date > DateTime.Now.AddDays(-7))
                 throw new AuthorizationFailedException("Reminders have already been sent the the last week");
 

--- a/Dan.Core/Models/Notifications/Altinn3NotificationModels.cs
+++ b/Dan.Core/Models/Notifications/Altinn3NotificationModels.cs
@@ -1,0 +1,347 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Dan.Core.Models.Notifications;
+
+/// <summary>
+/// Available notification channels in the Altinn Notifications API.
+/// Serialized by name (e.g. "EmailAndSms").
+/// </summary>
+[JsonConverter(typeof(StringEnumConverter))]
+public enum NotificationChannel
+{
+    Email,
+    Sms,
+    EmailPreferred,
+    SmsPreferred,
+    EmailAndSms
+}
+
+/// <summary>
+/// Content type for an email body.
+/// </summary>
+[JsonConverter(typeof(StringEnumConverter))]
+public enum EmailContentType
+{
+    Plain,
+    Html
+}
+
+/// <summary>
+/// Policy governing when a message may be delivered.
+/// </summary>
+[JsonConverter(typeof(StringEnumConverter))]
+public enum SendingTimePolicy
+{
+    Anytime,
+    Daytime
+}
+
+/// <summary>
+/// Email-specific settings used when the channel scheme includes email.
+/// </summary>
+public class EmailSendingOptions
+{
+    [JsonProperty("senderEmailAddress", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SenderEmailAddress { get; set; }
+
+    [JsonProperty("subject")]
+    public string Subject { get; set; } = string.Empty;
+
+    [JsonProperty("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [JsonProperty("contentType")]
+    public EmailContentType ContentType { get; set; } = EmailContentType.Plain;
+
+    [JsonProperty("sendingTimePolicy", NullValueHandling = NullValueHandling.Ignore)]
+    public SendingTimePolicy? SendingTimePolicy { get; set; }
+}
+
+/// <summary>
+/// SMS-specific settings used when the channel scheme includes SMS.
+/// </summary>
+public class SmsSendingOptions
+{
+    [JsonProperty("sender", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Sender { get; set; }
+
+    [JsonProperty("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [JsonProperty("sendingTimePolicy", NullValueHandling = NullValueHandling.Ignore)]
+    public SendingTimePolicy? SendingTimePolicy { get; set; }
+}
+
+/// <summary>
+/// Recipient targeted by national identity number; contact info is resolved from KRR.
+/// </summary>
+public class RecipientPerson
+{
+    [JsonProperty("nationalIdentityNumber")]
+    public string NationalIdentityNumber { get; set; } = string.Empty;
+
+    [JsonProperty("channelSchema")]
+    public NotificationChannel ChannelSchema { get; set; }
+
+    [JsonProperty("emailSettings", NullValueHandling = NullValueHandling.Ignore)]
+    public EmailSendingOptions? EmailSettings { get; set; }
+
+    [JsonProperty("smsSettings", NullValueHandling = NullValueHandling.Ignore)]
+    public SmsSendingOptions? SmsSettings { get; set; }
+
+    [JsonProperty("ignoreReservation")]
+    public bool IgnoreReservation { get; set; }
+}
+
+/// <summary>
+/// Recipient targeted by organization number; contact info is resolved from Enhetsregisteret.
+/// </summary>
+public class RecipientOrganization
+{
+    [JsonProperty("orgNumber")]
+    public string OrgNumber { get; set; } = string.Empty;
+
+    [JsonProperty("channelSchema")]
+    public NotificationChannel ChannelSchema { get; set; }
+
+    [JsonProperty("emailSettings", NullValueHandling = NullValueHandling.Ignore)]
+    public EmailSendingOptions? EmailSettings { get; set; }
+
+    [JsonProperty("smsSettings", NullValueHandling = NullValueHandling.Ignore)]
+    public SmsSendingOptions? SmsSettings { get; set; }
+}
+
+/// <summary>
+/// Container selecting exactly one recipient type for a notification order.
+/// </summary>
+public class NotificationRecipient
+{
+    [JsonProperty("recipientPerson", NullValueHandling = NullValueHandling.Ignore)]
+    public RecipientPerson? RecipientPerson { get; set; }
+
+    [JsonProperty("recipientOrganization", NullValueHandling = NullValueHandling.Ignore)]
+    public RecipientOrganization? RecipientOrganization { get; set; }
+}
+
+/// <summary>
+/// Request body for POST notifications/api/v1/future/orders.
+/// </summary>
+public class NotificationOrderChainRequest
+{
+    [JsonProperty("idempotencyId")]
+    public string IdempotencyId { get; set; } = string.Empty;
+
+    [JsonProperty("recipient")]
+    public NotificationRecipient Recipient { get; set; } = new();
+
+    [JsonProperty("sendersReference", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SendersReference { get; set; }
+
+    [JsonProperty("requestedSendTime", NullValueHandling = NullValueHandling.Ignore)]
+    public DateTime? RequestedSendTime { get; set; }
+
+    [JsonProperty("conditionEndpoint", NullValueHandling = NullValueHandling.Ignore)]
+    public Uri? ConditionEndpoint { get; set; }
+}
+
+/// <summary>
+/// Shipment tracking information returned for an order or reminder.
+/// </summary>
+public class NotificationOrderChainShipment
+{
+    [JsonProperty("shipmentId")]
+    public Guid ShipmentId { get; set; }
+
+    [JsonProperty("sendersReference")]
+    public string? SendersReference { get; set; }
+}
+
+/// <summary>
+/// Receipt for a created order chain, including any reminder shipments.
+/// </summary>
+public class NotificationOrderChainReceipt : NotificationOrderChainShipment
+{
+    [JsonProperty("reminders")]
+    public List<NotificationOrderChainShipment>? Reminders { get; set; }
+}
+
+/// <summary>
+/// Response from POST notifications/api/v1/future/orders.
+/// </summary>
+public class NotificationOrderChainResponse
+{
+    [JsonProperty("notificationOrderId")]
+    public Guid OrderChainId { get; set; }
+
+    [JsonProperty("notification")]
+    public NotificationOrderChainReceipt? OrderChainReceipt { get; set; }
+}
+
+/// <summary>
+/// Content and sender for an instant SMS.
+/// </summary>
+public class ShortMessageContent
+{
+    [JsonProperty("sender", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Sender { get; set; }
+
+    [JsonProperty("body")]
+    public string Body { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Delivery details for an instant SMS.
+/// </summary>
+public class ShortMessageDeliveryDetails
+{
+    [JsonProperty("phoneNumber")]
+    public string PhoneNumber { get; set; } = string.Empty;
+
+    [JsonProperty("timeToLiveInSeconds")]
+    public int TimeToLiveInSeconds { get; set; }
+
+    [JsonProperty("smsSettings")]
+    public ShortMessageContent ShortMessageContent { get; set; } = new();
+}
+
+/// <summary>
+/// Request body for POST notifications/api/v1/future/orders/instant/sms.
+/// </summary>
+public class InstantSmsNotificationOrderRequest
+{
+    [JsonProperty("idempotencyId")]
+    public string IdempotencyId { get; set; } = string.Empty;
+
+    [JsonProperty("sendersReference", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SendersReference { get; set; }
+
+    [JsonProperty("recipientSms")]
+    public ShortMessageDeliveryDetails RecipientSms { get; set; } = new();
+}
+
+/// <summary>
+/// Content and sender for an instant email.
+/// </summary>
+public class InstantEmailContent
+{
+    [JsonProperty("subject")]
+    public string Subject { get; set; } = string.Empty;
+
+    [JsonProperty("body")]
+    public string Body { get; set; } = string.Empty;
+
+    [JsonProperty("senderEmailAddress", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SenderEmailAddress { get; set; }
+
+    [JsonProperty("contentType")]
+    public EmailContentType ContentType { get; set; } = EmailContentType.Plain;
+}
+
+/// <summary>
+/// Recipient and content for an instant email.
+/// </summary>
+public class InstantEmailDetails
+{
+    [JsonProperty("emailAddress")]
+    public string EmailAddress { get; set; } = string.Empty;
+
+    [JsonProperty("emailSettings")]
+    public InstantEmailContent EmailSettings { get; set; } = new();
+}
+
+/// <summary>
+/// Request body for POST notifications/api/v1/future/orders/instant/email.
+/// </summary>
+public class InstantEmailNotificationOrderRequest
+{
+    [JsonProperty("idempotencyId")]
+    public string IdempotencyId { get; set; } = string.Empty;
+
+    [JsonProperty("sendersReference", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SendersReference { get; set; }
+
+    [JsonProperty("recipientEmail")]
+    public InstantEmailDetails RecipientEmail { get; set; } = new();
+}
+
+/// <summary>
+/// Response from the instant order endpoints.
+/// </summary>
+public class InstantNotificationOrderResponse
+{
+    [JsonProperty("notificationOrderId")]
+    public Guid OrderChainId { get; set; }
+
+    [JsonProperty("notification")]
+    public NotificationOrderChainShipment? Notification { get; set; }
+}
+
+/// <summary>
+/// Status summary for a single notification channel.
+/// </summary>
+public class NotificationChannelStatus
+{
+    [JsonProperty("generated")]
+    public int Generated { get; set; }
+
+    [JsonProperty("succeeded")]
+    public int Succeeded { get; set; }
+}
+
+/// <summary>
+/// Summary of per-channel notification statuses.
+/// </summary>
+public class NotificationsStatusSummary
+{
+    [JsonProperty("email")]
+    public NotificationChannelStatus? Email { get; set; }
+
+    [JsonProperty("sms")]
+    public NotificationChannelStatus? Sms { get; set; }
+}
+
+/// <summary>
+/// Processing status of a notification order.
+/// </summary>
+public class OrderProcessingStatus
+{
+    [JsonProperty("status")]
+    public string Status { get; set; } = string.Empty;
+
+    [JsonProperty("description")]
+    public string? StatusDescription { get; set; }
+
+    [JsonProperty("lastUpdate")]
+    public DateTime LastUpdate { get; set; }
+}
+
+/// <summary>
+/// Response from GET notifications/api/v1/orders/{id}/status.
+/// </summary>
+public class NotificationOrderWithStatus
+{
+    [JsonProperty("id")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonProperty("sendersReference")]
+    public string? SendersReference { get; set; }
+
+    [JsonProperty("requestedSendTime")]
+    public DateTime RequestedSendTime { get; set; }
+
+    [JsonProperty("creator")]
+    public string Creator { get; set; } = string.Empty;
+
+    [JsonProperty("created")]
+    public DateTime Created { get; set; }
+
+    [JsonProperty("notificationChannel")]
+    public NotificationChannel NotificationChannel { get; set; }
+
+    [JsonProperty("processingStatus")]
+    public OrderProcessingStatus ProcessingStatus { get; set; } = new();
+
+    [JsonProperty("notificationsStatusSummary")]
+    public NotificationsStatusSummary? NotificationsStatusSummary { get; set; }
+}

--- a/Dan.Core/Program.cs
+++ b/Dan.Core/Program.cs
@@ -158,6 +158,7 @@ var host = new HostBuilder()
         services.AddScoped<IEvidenceHarvesterService, EvidenceHarvesterService>();
         services.AddScoped<IConsentService, ConsentService>();
         services.AddScoped<IAltinn3ConsentService, Altinn3ConsentService>();
+        services.AddScoped<IAltinn3NotificationsService, Altinn3NotificationsService>();
         services.AddScoped<IRequirementValidationService, RequirementValidationService>();
         services.AddScoped<IAuthorizationRequestValidatorService, AuthorizationRequestValidatorService>();
         services.AddScoped<IRequestContextService, RequestContextService>();
@@ -253,6 +254,14 @@ var host = new HostBuilder()
                 client.DefaultRequestHeaders.Add("Accept", "application/json");
                 client.Timeout = TimeSpan.FromSeconds(5);
             })
+            .AddHttpMessageHandler<ExceptionDelegatingHandler>();
+
+        // Client used for the Altinn 3 Notifications API
+        services.AddHttpClient(Constants.Altinn3NotificationsHttpClient, client =>
+            {
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
+            })
+            .AddPolicyHandlerFromRegistry("DefaultCircuitBreaker")
             .AddHttpMessageHandler<ExceptionDelegatingHandler>();
 
     })

--- a/Dan.Core/Services/Altinn3NotificationsService.cs
+++ b/Dan.Core/Services/Altinn3NotificationsService.cs
@@ -245,6 +245,15 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
         }
 
         var content = await response.Content.ReadAsStringAsync();
-        return JsonConvert.DeserializeObject<T>(content)!;
+        var result = JsonConvert.DeserializeObject<T>(content);
+        if (result == null)
+        {
+            _logger.LogError(
+                "Notifications API returned success but the response could not be deserialized method={method} path={path}",
+                method, relativePath);
+            throw new ServiceNotAvailableException("Unexpected response from the Altinn Notifications API");
+        }
+
+        return result;
     }
 }

--- a/Dan.Core/Services/Altinn3NotificationsService.cs
+++ b/Dan.Core/Services/Altinn3NotificationsService.cs
@@ -1,0 +1,250 @@
+using Dan.Common;
+using Dan.Common.Models;
+using Dan.Core.Config;
+using Dan.Core.Exceptions;
+using Dan.Core.Extensions;
+using Dan.Core.Helpers;
+using Dan.Core.Models.Notifications;
+using Dan.Core.Services.Interfaces;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Net;
+
+namespace Dan.Core.Services;
+
+/// <summary>
+/// Sends notifications via the Altinn 3 Notifications API. Authenticates with a raw
+/// Maskinporten token (reusing <see cref="ITokenRequesterService"/>), exactly like
+/// <see cref="Altinn3ConsentService"/> does for the consent API.
+/// </summary>
+public class Altinn3NotificationsService : IAltinn3NotificationsService
+{
+    private const string FromAddress = "no-reply@altinn.no";
+
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ITokenRequesterService _tokenRequesterService;
+    private readonly Interfaces.IEntityRegistryService _entityRegistryService;
+    private readonly ILogger<Altinn3NotificationsService> _logger;
+
+    public Altinn3NotificationsService(
+        IHttpClientFactory httpClientFactory,
+        ITokenRequesterService tokenRequesterService,
+        Interfaces.IEntityRegistryService entityRegistryService,
+        ILogger<Altinn3NotificationsService> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _tokenRequesterService = tokenRequesterService;
+        _entityRegistryService = entityRegistryService;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<List<NotificationReminder>> SendReminder(Accreditation accreditation, ServiceContext serviceContext)
+    {
+        var order = await BuildReminderOrder(accreditation, serviceContext);
+
+        try
+        {
+            var response = await CreateOrder(order);
+            _logger.LogInformation(
+                "Sent consent reminder notification order aid={accreditationId} notificationOrderId={notificationOrderId}",
+                accreditation.AccreditationId, response.OrderChainId);
+
+            return new List<NotificationReminder>
+            {
+                CreateReminderReceipt("Sent", true, "Email"),
+                CreateReminderReceipt("Sent", true, "SMS")
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                "Failed to send consent reminder notification order aid={accreditationId} exception={exception}",
+                accreditation.AccreditationId, ex.Message);
+
+            return new List<NotificationReminder>
+            {
+                CreateReminderReceipt("Failed", false, "Email"),
+                CreateReminderReceipt("Failed", false, "SMS")
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<NotificationOrderChainResponse> CreateOrder(NotificationOrderChainRequest order)
+    {
+        return await Send<NotificationOrderChainResponse>(HttpMethod.Post, "future/orders", order);
+    }
+
+    /// <inheritdoc />
+    public async Task<InstantNotificationOrderResponse> CreateInstantSmsOrder(InstantSmsNotificationOrderRequest order)
+    {
+        return await Send<InstantNotificationOrderResponse>(HttpMethod.Post, "future/orders/instant/sms", order);
+    }
+
+    /// <inheritdoc />
+    public async Task<InstantNotificationOrderResponse> CreateInstantEmailOrder(InstantEmailNotificationOrderRequest order)
+    {
+        return await Send<InstantNotificationOrderResponse>(HttpMethod.Post, "future/orders/instant/email", order);
+    }
+
+    /// <inheritdoc />
+    public async Task<NotificationOrderWithStatus?> GetOrderStatus(Guid orderId)
+    {
+        return await Send<NotificationOrderWithStatus?>(HttpMethod.Get, $"orders/{orderId}/status", null, HttpStatusCode.NotFound);
+    }
+
+    private async Task<NotificationOrderChainRequest> BuildReminderOrder(Accreditation accreditation, ServiceContext serviceContext)
+    {
+        if (accreditation.RequestorParty == null)
+        {
+            throw new InvalidRequestorException("Accreditation missing requestor party");
+        }
+
+        if (accreditation.SubjectParty == null)
+        {
+            throw new InvalidSubjectException("Accreditation missing subject party");
+        }
+
+        var requestorName = await GetPartyDisplayName(accreditation.RequestorParty);
+        var subjectName = await GetPartyDisplayName(accreditation.SubjectParty);
+
+        var renderedTexts = TextTemplateProcessor.GetRenderedTexts(serviceContext, accreditation, requestorName, subjectName, null);
+
+        var emailSettings = new EmailSendingOptions
+        {
+            SenderEmailAddress = FromAddress,
+            Subject = renderedTexts.EmailNotificationSubject,
+            Body = renderedTexts.EmailNotificationContent,
+            ContentType = EmailContentType.Plain
+        };
+
+        var smsSettings = new SmsSendingOptions
+        {
+            Body = renderedTexts.SMSNotificationContent
+        };
+
+        var recipient = BuildRecipient(accreditation.SubjectParty, emailSettings, smsSettings);
+
+        return new NotificationOrderChainRequest
+        {
+            // Idempotency id must be unique per send; reminders may be sent repeatedly (>7 days apart).
+            IdempotencyId = $"dan-reminder-{accreditation.AccreditationId}-{Guid.NewGuid():N}",
+            SendersReference = accreditation.AccreditationId,
+            RequestedSendTime = DateTime.UtcNow.AddMinutes(1),
+            Recipient = recipient
+        };
+    }
+
+    private static NotificationRecipient BuildRecipient(Party subjectParty, EmailSendingOptions emailSettings, SmsSendingOptions smsSettings)
+    {
+        if (!string.IsNullOrWhiteSpace(subjectParty.NorwegianOrganizationNumber))
+        {
+            return new NotificationRecipient
+            {
+                RecipientOrganization = new RecipientOrganization
+                {
+                    OrgNumber = subjectParty.NorwegianOrganizationNumber,
+                    ChannelSchema = NotificationChannel.EmailAndSms,
+                    EmailSettings = emailSettings,
+                    SmsSettings = smsSettings
+                }
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(subjectParty.NorwegianSocialSecurityNumber))
+        {
+            return new NotificationRecipient
+            {
+                RecipientPerson = new RecipientPerson
+                {
+                    NationalIdentityNumber = subjectParty.NorwegianSocialSecurityNumber,
+                    ChannelSchema = NotificationChannel.EmailAndSms,
+                    EmailSettings = emailSettings,
+                    SmsSettings = smsSettings
+                }
+            };
+        }
+
+        throw new InvalidSubjectException(
+            "Cannot send reminder: subject party has neither a Norwegian organization number nor a national identity number");
+    }
+
+    private async Task<string> GetPartyDisplayName(Party party)
+    {
+        if (party.NorwegianOrganizationNumber == null)
+        {
+            // Party.ToString() masks the social security number.
+            return party.ToString();
+        }
+
+        var result = await _entityRegistryService.Get(party.NorwegianOrganizationNumber);
+        return result?.Name ?? party.NorwegianOrganizationNumber;
+    }
+
+    private static NotificationReminder CreateReminderReceipt(string description, bool success, string type)
+    {
+        return new NotificationReminder
+        {
+            Description = description,
+            Success = success,
+            NotificationType = type,
+            RecipientCount = success ? 1 : 0,
+            Date = DateTime.Now
+        };
+    }
+
+    /// <summary>
+    /// Builds an authenticated request to the Notifications API, sends it and deserializes the response.
+    /// Throws <see cref="ServiceNotAvailableException"/> on unexpected (non-allowed) error responses.
+    /// </summary>
+    private async Task<T> Send<T>(HttpMethod method, string relativePath, object? body, params HttpStatusCode[] allowedErrorCodes)
+    {
+        var client = _httpClientFactory.CreateClient(Constants.Altinn3NotificationsHttpClient);
+
+        var baseUrl = Settings.NotificationsApiBaseUrl.TrimEnd('/');
+        var request = new HttpRequestMessage(method, $"{baseUrl}/{relativePath}");
+
+        // The Notifications API requires an Altinn token, so exchange the Maskinporten token first.
+        var tokenResponse = JsonConvert.DeserializeObject<Dictionary<string, string>>(
+            await _tokenRequesterService.GetAltinnExchangedToken(Settings.NotificationsCreateScope));
+        if (tokenResponse == null || !tokenResponse.TryGetValue(Constants.ACCESS_TOKEN, out var accessToken))
+        {
+            throw new ServiceNotAvailableException("Temporarily unable to retrieve authentication token for the Notifications API");
+        }
+
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {accessToken}");
+
+        if (body != null)
+        {
+            // JsonContent forces the method to POST, so set the content directly for non-POST verbs.
+            request.Content = new System.Net.Http.StringContent(
+                JsonConvert.SerializeObject(body), System.Text.Encoding.UTF8, "application/json");
+        }
+
+        if (allowedErrorCodes.Length > 0)
+        {
+            request.SetAllowedErrorCodes(allowedErrorCodes);
+        }
+
+        var response = await client.SendAsync(request);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            if (allowedErrorCodes.Contains(response.StatusCode))
+            {
+                // Caller-handled error (e.g. 404 on status lookup) — return default.
+                return default!;
+            }
+
+            _logger.LogError(
+                "Notifications API call failed method={method} path={path} statusCode={statusCode} reasonPhrase={reasonPhrase}",
+                method, relativePath, response.StatusCode, response.ReasonPhrase);
+            throw new ServiceNotAvailableException("The Altinn Notifications API returned an error. This is an internal error, please contact support");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<T>(content)!;
+    }
+}

--- a/Dan.Core/Services/Interfaces/IAltinn3NotificationsService.cs
+++ b/Dan.Core/Services/Interfaces/IAltinn3NotificationsService.cs
@@ -1,0 +1,42 @@
+using Dan.Common.Models;
+using Dan.Core.Models.Notifications;
+
+namespace Dan.Core.Services.Interfaces;
+
+/// <summary>
+/// Sends notifications (SMS/email) via the Altinn 3 Notifications API.
+/// Replaces the legacy Altinn correspondence notification path for consent reminders.
+/// </summary>
+public interface IAltinn3NotificationsService
+{
+    /// <summary>
+    /// Sends a consent reminder to the accreditation subject as a standard notification order
+    /// (sent now), using both email and SMS. Mirrors the previous
+    /// <c>IAltinnCorrespondenceService.SendNotification</c> signature so the result can be
+    /// stored directly on the accreditation.
+    /// </summary>
+    /// <param name="accreditation">The related accreditation.</param>
+    /// <param name="serviceContext">The current service context (holds the text templates).</param>
+    /// <returns>One reminder receipt per channel (email and SMS).</returns>
+    Task<List<NotificationReminder>> SendReminder(Accreditation accreditation, ServiceContext serviceContext);
+
+    /// <summary>
+    /// Creates a notification order (future/standard order) and returns the order chain receipt.
+    /// </summary>
+    Task<NotificationOrderChainResponse> CreateOrder(NotificationOrderChainRequest order);
+
+    /// <summary>
+    /// Creates and immediately sends an SMS notification to a single recipient.
+    /// </summary>
+    Task<InstantNotificationOrderResponse> CreateInstantSmsOrder(InstantSmsNotificationOrderRequest order);
+
+    /// <summary>
+    /// Creates and immediately sends an email notification to a single recipient.
+    /// </summary>
+    Task<InstantNotificationOrderResponse> CreateInstantEmailOrder(InstantEmailNotificationOrderRequest order);
+
+    /// <summary>
+    /// Retrieves the processing status of a previously created notification order.
+    /// </summary>
+    Task<NotificationOrderWithStatus?> GetOrderStatus(Guid orderId);
+}

--- a/Dan.Core/Services/Interfaces/ITokenRequesterService.cs
+++ b/Dan.Core/Services/Interfaces/ITokenRequesterService.cs
@@ -9,4 +9,12 @@ public interface ITokenRequesterService
 {
     Task<string> GetMaskinportenToken(string scopes, string? consumerOrgNo = null);
     Task<string> GetMaskinportenConsentToken(string consentId, string offeredby, EvidenceCode evidenceCodes);
+
+    /// <summary>
+    /// Requests a Maskinporten token for the given scopes and exchanges it for an Altinn token,
+    /// as required by Altinn platform APIs (e.g. the Notifications API). Returns the same
+    /// <c>{ "access_token": ..., "expires_in": ... }</c> JSON shape as <see cref="GetMaskinportenToken"/>,
+    /// where <c>access_token</c> is the exchanged Altinn token.
+    /// </summary>
+    Task<string> GetAltinnExchangedToken(string scopes, string? consumerOrgNo = null);
 }

--- a/Dan.Core/Services/TokenRequesterService.cs
+++ b/Dan.Core/Services/TokenRequesterService.cs
@@ -4,6 +4,7 @@ using Dan.Core.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Polly;
 using Polly.Registry;
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -11,6 +12,7 @@ using System.Text;
 using Dan.Core.Exceptions;
 using Microsoft.IdentityModel.Tokens;
 using Dan.Common.Models;
+using Newtonsoft.Json;
 
 namespace Dan.Core.Services;
 
@@ -40,6 +42,54 @@ public class TokenRequesterService : ITokenRequesterService
         var cachePolicy = _policyRegistry.Get<AsyncPolicy<string>>(CachingPolicy);
         return await cachePolicy.ExecuteAsync(async _ => await GetMaskinportenTokenInternal(scopes, consumerOrgNo),
             new Context(GetCacheKey(scopes, consumerOrgNo, null, null)));
+    }
+
+    public async Task<string> GetAltinnExchangedToken(string scopes, string? consumerOrgNo = null)
+    {
+        var cachePolicy = _policyRegistry.Get<AsyncPolicy<string>>(CachingPolicy);
+        return await cachePolicy.ExecuteAsync(async _ => await GetAltinnExchangedTokenInternal(scopes, consumerOrgNo),
+            new Context("altexch_" + GetCacheKey(scopes, consumerOrgNo, null, null)));
+    }
+
+    private async Task<string> GetAltinnExchangedTokenInternal(string scopes, string? consumerOrgNo)
+    {
+        // The cached Maskinporten token (reused as-is) is the input to the exchange.
+        var maskinportenJson = await GetMaskinportenToken(scopes, consumerOrgNo);
+        var maskinportenToken = JsonConvert.DeserializeObject<Dictionary<string, string>>(maskinportenJson);
+        if (maskinportenToken == null
+            || !maskinportenToken.TryGetValue("access_token", out var maskinportenAccessToken)
+            || string.IsNullOrEmpty(maskinportenAccessToken))
+        {
+            throw new ServiceNotAvailableException("Failed getting Maskinporten token to exchange for an Altinn token");
+        }
+
+        // Exchange the Maskinporten token for an Altinn token (GET with the Maskinporten token as bearer).
+        var request = new HttpRequestMessage(HttpMethod.Get, Settings.AltinnTokenExchangeUrl);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", maskinportenAccessToken);
+
+        var response = await _client.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("Failed exchanging Maskinporten token for an Altinn token - response status={statusCode}",
+                response.StatusCode);
+            throw new ServiceNotAvailableException("Failed exchanging Maskinporten token for an Altinn token");
+        }
+
+        // The exchange endpoint returns the Altinn token as a JSON-quoted string.
+        var altinnToken = JsonConvert.DeserializeObject<string>(await response.Content.ReadAsStringAsync());
+        if (string.IsNullOrEmpty(altinnToken))
+        {
+            throw new ServiceNotAvailableException("Altinn token exchange returned an empty token");
+        }
+
+        // Wrap in the same shape as the Maskinporten token response and reuse its lifetime, so the
+        // existing Oauth2AccessTokenCachingStrategy can cache the exchanged token alongside it.
+        maskinportenToken.TryGetValue("expires_in", out var expiresIn);
+        return JsonConvert.SerializeObject(new Dictionary<string, string>
+        {
+            ["access_token"] = altinnToken,
+            ["expires_in"] = string.IsNullOrEmpty(expiresIn) ? "0" : expiresIn
+        });
     }
 
     public async Task<string> GetMaskinportenConsentToken(string consentId, string offeredBy, EvidenceCode evidenceCode)

--- a/Dan.Core/local.settings.json.template
+++ b/Dan.Core/local.settings.json.template
@@ -86,6 +86,9 @@
 
     "MaskinportenUrl": "https://ver2.maskinporten.no/",
     "MaskinportenWellknownUrl": "https://ver2.maskinporten.no/.well-known/oauth-authorization-server",
-    "AltinnWellknownUrl": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration"
+    "AltinnWellknownUrl": "https://platform.tt02.altinn.no/authentication/api/v1/openid/.well-known/openid-configuration",
+
+    "NotificationsApiBaseUrl": "https://platform.tt02.altinn.no/notifications/api/v1",
+    "AltinnTokenExchangeUrl": "https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten"
   }
 }


### PR DESCRIPTION
## Summary

Moves consent reminders (SMS + email) off the legacy Altinn correspondence WCF service onto the **Altinn 3 Notifications API**.

Flow: `FuncConsentReminder` → `IAltinn3NotificationsService.SendReminder` → `POST /notifications/api/v1/future/orders`.

## Changes

- **New `Altinn3NotificationsService` / `IAltinn3NotificationsService`** — `SendReminder` (drop-in for the old `SendNotification`, returns `List<NotificationReminder>`) plus `CreateOrder`, `CreateInstantSmsOrder`, `CreateInstantEmailOrder`, and `GetOrderStatus` implemented for later use.
- **`FuncConsentReminder`** — now injects/calls the new service. The old `AltinnCorrespondenceService` is left intact (its `SendCorrespondence` is unused here; correspondence is handled by `Altinn.Dd.Correspondence`).
- **Reminder order** — standard future order with `notificationChannel = EmailAndSms`, recipient resolved as organization (orgNumber) or person (nationalIdentityNumber) from `SubjectParty`; email/SMS bodies rendered by the existing `TextTemplateProcessor`.
- **Maskinporten → Altinn token exchange** — the Notifications API requires an Altinn token, so `TokenRequesterService` gained `GetAltinnExchangedToken` (modeled on `Altinn.ApiClients.Maskinporten`'s `ExchangeToAltinnToken`). The exchanged token is cached via the existing `Oauth2AccessTokenCachingStrategy`.
- **7-day resend guard** — now only counts *successful* reminders, so a failed send no longer blocks retries for a week.
- **DTOs** — `Dan.Core/Models/Notifications/`, schema taken from the authoritative `*Ext` models in `Altinn/altinn-notifications`.
- **Settings** — `NotificationsApiBaseUrl` and `AltinnTokenExchangeUrl` (configurable); `NotificationsCreateScope` is a fixed value.

## Notes / decisions

- `notificationChannel` is `EmailAndSms` to match the previous behavior of sending both.
- Plain token exchange — no `?test=true` / enterprise-user header (DAN authenticates as a real org). Verified working in TT02.
- API failures during order creation are caught and returned as `NotificationReminder` receipts with `Success=false` (HTTP 200) — same contract as the old correspondence path.

## Testing

- `dotnet build` — clean.
- `dotnet test Dan.Core.UnitTest` — **118 passed** (113 existing + 5 new covering channel/recipient mapping, failure handling, status 404, and the instant endpoint).
- Manually verified end-to-end in TT02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Altinn3 Notifications API for sending accreditation reminders via SMS and email channels
  * Added support for instant email and SMS notifications with order status tracking
  * Implemented secure token exchange for API authentication

* **Bug Fixes**
  * Enhanced reminder frequency validation to track only successfully sent reminders

* **Tests**
  * Added comprehensive unit tests for notification service functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->