### PR TITLE
feat(notifications): resource targeting on reminder orders + tighten A3 consent guard

### DIFF
--- a/Dan.Core.UnitTest/Altinn3NotificationsServiceTest.cs
+++ b/Dan.Core.UnitTest/Altinn3NotificationsServiceTest.cs
@@ -80,6 +80,8 @@ namespace Dan.Core.UnitTest
             Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.EmailSettings!.Subject));
             Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.EmailSettings.Body));
             Assert.IsFalse(string.IsNullOrWhiteSpace(order.Recipient.RecipientOrganization.SmsSettings!.Body));
+            Assert.AreEqual("urn:altinn:resource:digdir-data-altinn-no-melding", order.Recipient.RecipientOrganization.ResourceId);
+            Assert.AreEqual("read", order.Recipient.RecipientOrganization.ResourceAction);
         }
 
         [TestMethod]
@@ -111,6 +113,8 @@ namespace Dan.Core.UnitTest
             Assert.IsNull(order.Recipient.RecipientOrganization);
             Assert.AreEqual("08075412345", order.Recipient.RecipientPerson!.NationalIdentityNumber);
             Assert.AreEqual(NotificationChannel.EmailAndSms, order.Recipient.RecipientPerson.ChannelSchema);
+            Assert.AreEqual("urn:altinn:resource:digdir-data-altinn-no-melding", order.Recipient.RecipientPerson.ResourceId);
+            Assert.AreEqual("read", order.Recipient.RecipientPerson.ResourceAction);
         }
 
         [TestMethod]
@@ -219,7 +223,17 @@ namespace Dan.Core.UnitTest
                 ConsentReference = "2019-2312",
                 ExternalReference = "externalreference",
                 LanguageCode = Constants.LANGUAGE_CODE_NORWEGIAN_NB,
-                EvidenceCodes = new List<EvidenceCode>()
+                EvidenceCodes = new List<EvidenceCode>
+                {
+                    new EvidenceCode
+                    {
+                        EvidenceCodeName = "TestEvidenceCode",
+                        AuthorizationRequirements = new List<Requirement>
+                        {
+                            new ConsentRequirement { AltinnResource = "test-consent-resource" }
+                        }
+                    }
+                }
             };
         }
     }

--- a/Dan.Core/Config/Settings.cs
+++ b/Dan.Core/Config/Settings.cs
@@ -395,6 +395,8 @@ public static class Settings
     /// </summary>
     public static string NotificationsApiBaseUrl => GetSetting("NotificationsApiBaseUrl");
 
+    public static string AltinnMessageResource => "digdir-data-altinn-no-melding";
+
     /// <summary>
     /// Maskinporten scope used when creating notification orders, e.g. altinn:serviceowner/notifications.create
     /// </summary>

--- a/Dan.Core/FuncConsentReminder.cs
+++ b/Dan.Core/FuncConsentReminder.cs
@@ -89,6 +89,9 @@ namespace Dan.Core
             if (!string.IsNullOrEmpty(accr.AuthorizationCode))
                 throw new ConsentAlreadyHandledException($"Consent has already been given or rejected for {accreditationId}");
 
+            if (!string.IsNullOrEmpty(accr.Altinn3ConsentId) && !string.IsNullOrEmpty(accr.Altinn3ConsentStatus))
+                throw new ConsentAlreadyHandledException($"Consent has already been given or rejected for {accreditationId}");
+
             if (accr.ValidTo < DateTime.Now)
                 throw new ExpiredConsentException("The consent for this accreditation is expired");
 

--- a/Dan.Core/FuncConsentReminder.cs
+++ b/Dan.Core/FuncConsentReminder.cs
@@ -89,7 +89,7 @@ namespace Dan.Core
             if (!string.IsNullOrEmpty(accr.AuthorizationCode))
                 throw new ConsentAlreadyHandledException($"Consent has already been given or rejected for {accreditationId}");
 
-            if (!string.IsNullOrEmpty(accr.Altinn3ConsentId) && !string.IsNullOrEmpty(accr.Altinn3ConsentStatus))
+            if (!string.IsNullOrEmpty(accr.Altinn3ConsentStatus))
                 throw new ConsentAlreadyHandledException($"Consent has already been given or rejected for {accreditationId}");
 
             if (accr.ValidTo < DateTime.Now)

--- a/Dan.Core/Models/Notifications/Altinn3NotificationModels.cs
+++ b/Dan.Core/Models/Notifications/Altinn3NotificationModels.cs
@@ -92,6 +92,19 @@ public class RecipientPerson
 
     [JsonProperty("ignoreReservation")]
     public bool IgnoreReservation { get; set; }
+
+    /// <summary>
+    /// The resource the notification relates to, as a "urn:altinn:resource:{id}" URN.
+    /// Required for the notification to be delivered to the correct recipients.
+    /// </summary>
+    [JsonProperty("resourceId", NullValueHandling = NullValueHandling.Ignore)]
+    public string? ResourceId { get; set; }
+
+    /// <summary>
+    /// The action on the resource the notification relates to (e.g. "read").
+    /// </summary>
+    [JsonProperty("resourceAction", NullValueHandling = NullValueHandling.Ignore)]
+    public string? ResourceAction { get; set; }
 }
 
 /// <summary>
@@ -110,6 +123,19 @@ public class RecipientOrganization
 
     [JsonProperty("smsSettings", NullValueHandling = NullValueHandling.Ignore)]
     public SmsSendingOptions? SmsSettings { get; set; }
+
+    /// <summary>
+    /// The resource the notification relates to, as a "urn:altinn:resource:{id}" URN.
+    /// Required for the notification to be delivered to the correct recipients.
+    /// </summary>
+    [JsonProperty("resourceId", NullValueHandling = NullValueHandling.Ignore)]
+    public string? ResourceId { get; set; }
+
+    /// <summary>
+    /// The action on the resource the notification relates to (e.g. "read").
+    /// </summary>
+    [JsonProperty("resourceAction", NullValueHandling = NullValueHandling.Ignore)]
+    public string? ResourceAction { get; set; }
 }
 
 /// <summary>

--- a/Dan.Core/Program.cs
+++ b/Dan.Core/Program.cs
@@ -283,7 +283,7 @@ void AddAltinn3Messaging(IServiceCollection services)
             EnableDebugLogging = Settings.MaskinportenUrl.Contains("test"),
             EncodedX509 = encodedCert
         };
-        options.ResourceId = "digdir-data-altinn-no-melding";        
+        options.ResourceId = Settings.AltinnMessageResource;        
         options.Environment = Settings.MaskinportenUrl.Contains("test") ? ApiEnvironment.Staging : ApiEnvironment.Production;       
     });
 }

--- a/Dan.Core/Services/Altinn3NotificationsService.cs
+++ b/Dan.Core/Services/Altinn3NotificationsService.cs
@@ -9,6 +9,7 @@ using Dan.Core.Services.Interfaces;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Net;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Dan.Core.Services;
 
@@ -20,6 +21,8 @@ namespace Dan.Core.Services;
 public class Altinn3NotificationsService : IAltinn3NotificationsService
 {
     private const string FromAddress = "no-reply@altinn.no";
+    private const string ResourceUrnPrefix = "urn:altinn:resource:";
+    private const string ResourceAction = "read";
 
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly ITokenRequesterService _tokenRequesterService;
@@ -48,7 +51,7 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
             var response = await CreateOrder(order);
             _logger.LogInformation(
                 "Sent consent reminder notification order aid={accreditationId} notificationOrderId={notificationOrderId}",
-                accreditation.AccreditationId, response.OrderChainId);
+                accreditation.AccreditationId, response.OrderChainId);         
 
             return new List<NotificationReminder>
             {
@@ -113,7 +116,8 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
 
         var emailSettings = new EmailSendingOptions
         {
-            SenderEmailAddress = FromAddress,
+            //defaults to noreply@altinn.no
+            //SenderEmailAddress = FromAddress,
             Subject = renderedTexts.EmailNotificationSubject,
             Body = renderedTexts.EmailNotificationContent,
             ContentType = EmailContentType.Plain
@@ -124,19 +128,21 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
             Body = renderedTexts.SMSNotificationContent
         };
 
-        var recipient = BuildRecipient(accreditation.SubjectParty, emailSettings, smsSettings);
+        var resourceId = GetNotificationResourceUrn(accreditation);
+
+        var recipient = BuildRecipient(accreditation.SubjectParty, emailSettings, smsSettings, resourceId);
 
         return new NotificationOrderChainRequest
         {
             // Idempotency id must be unique per send; reminders may be sent repeatedly (>7 days apart).
             IdempotencyId = $"dan-reminder-{accreditation.AccreditationId}-{Guid.NewGuid():N}",
             SendersReference = accreditation.AccreditationId,
-            RequestedSendTime = DateTime.UtcNow.AddMinutes(1),
+            //RequestedSendTime = DateTime.UtcNow.AddMinutes(1),
             Recipient = recipient
         };
     }
 
-    private static NotificationRecipient BuildRecipient(Party subjectParty, EmailSendingOptions emailSettings, SmsSendingOptions smsSettings)
+    private static NotificationRecipient BuildRecipient(Party subjectParty, EmailSendingOptions emailSettings, SmsSendingOptions smsSettings, string resourceId)
     {
         if (!string.IsNullOrWhiteSpace(subjectParty.NorwegianOrganizationNumber))
         {
@@ -147,7 +153,9 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
                     OrgNumber = subjectParty.NorwegianOrganizationNumber,
                     ChannelSchema = NotificationChannel.EmailAndSms,
                     EmailSettings = emailSettings,
-                    SmsSettings = smsSettings
+                    SmsSettings = smsSettings,
+                    ResourceId = resourceId,
+                    ResourceAction = ResourceAction
                 }
             };
         }
@@ -161,13 +169,37 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
                     NationalIdentityNumber = subjectParty.NorwegianSocialSecurityNumber,
                     ChannelSchema = NotificationChannel.EmailAndSms,
                     EmailSettings = emailSettings,
-                    SmsSettings = smsSettings
+                    SmsSettings = smsSettings,
+                    ResourceId = resourceId,
+                    ResourceAction = ResourceAction
                 }
             };
         }
 
         throw new InvalidSubjectException(
             "Cannot send reminder: subject party has neither a Norwegian organization number nor a national identity number");
+    }
+
+    /// <summary>
+    /// Resolves the Altinn 3 consent resource URN ("urn:altinn:resource:{id}") from the consent
+    /// requirement on the accreditation's evidence codes. The Notifications API uses this to target
+    /// the correct recipients, so it must be present (the A3 consent request enforces the same).
+    /// </summary>
+    private static string GetNotificationResourceUrn(Accreditation accreditation)
+    {
+        /* var resourceIdentifier = accreditation.EvidenceCodes
+             .SelectMany(ec => ec.AuthorizationRequirements.OfType<ConsentRequirement>())
+             .Select(cr => cr.AltinnResource)
+             .FirstOrDefault(r => !string.IsNullOrEmpty(r)); 
+
+
+         if (string.IsNullOrEmpty(resourceIdentifier))
+         {
+             throw new InternalServerErrorException(
+                 "Cannot send reminder: no Altinn resource is defined on the consent requirement for the accreditation");
+         } */
+
+        return ResourceUrnPrefix + Settings.AltinnMessageResource;
     }
 
     private async Task<string> GetPartyDisplayName(Party party)

--- a/Dan.Core/Services/Altinn3NotificationsService.cs
+++ b/Dan.Core/Services/Altinn3NotificationsService.cs
@@ -181,24 +181,11 @@ public class Altinn3NotificationsService : IAltinn3NotificationsService
     }
 
     /// <summary>
-    /// Resolves the Altinn 3 consent resource URN ("urn:altinn:resource:{id}") from the consent
-    /// requirement on the accreditation's evidence codes. The Notifications API uses this to target
-    /// the correct recipients, so it must be present (the A3 consent request enforces the same).
+    /// Resource urn used in altinn 3. The Notifications API uses this to target
+    /// the correct recipients when be present (the A3 consent request enforces the same).
     /// </summary>
     private static string GetNotificationResourceUrn(Accreditation accreditation)
     {
-        /* var resourceIdentifier = accreditation.EvidenceCodes
-             .SelectMany(ec => ec.AuthorizationRequirements.OfType<ConsentRequirement>())
-             .Select(cr => cr.AltinnResource)
-             .FirstOrDefault(r => !string.IsNullOrEmpty(r)); 
-
-
-         if (string.IsNullOrEmpty(resourceIdentifier))
-         {
-             throw new InternalServerErrorException(
-                 "Cannot send reminder: no Altinn resource is defined on the consent requirement for the accreditation");
-         } */
-
         return ResourceUrnPrefix + Settings.AltinnMessageResource;
     }
 


### PR DESCRIPTION
## Summary

Two related changes to the Altinn 3 consent reminder flow:

### Notification resource targeting
The Notifications `future/orders` request now carries the resource the notification relates to, so it is delivered to the correct recipients:
- Added `resourceId` and `resourceAction` to the recipient models (`RecipientPerson` and `RecipientOrganization`).
- Reminder orders set `resourceId` to `urn:altinn:resource:digdir-data-altinn-no-melding` (via the new `Settings.AltinnMessageResource`) and `resourceAction` to `"read"`.
- `Program.cs` now reuses `Settings.AltinnMessageResource` instead of a hardcoded literal.

### Tighten the "consent already handled" guard
`ValidateAccreditationForReminder` now keys the Altinn 3 check solely on `Altinn3ConsentStatus`. That field is `null` while consent is pending and is set to `"ok"`/`"denied"` only once the subject acts (in `FuncConsentReceipt`), so reminders are still allowed for pending consents but blocked once consent has been given or rejected. The previous `Altinn3ConsentId &&` conjunct was redundant — every handled case is already covered by either the `AuthorizationCode` check or a non-empty status.

## Testing

- `dotnet build` — 0 errors
- `dotnet test` — 118 Dan.Core + 20 Dan.Common passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reminder notifications now include resource-related details for both people and organizations.
  * System configuration now supports a dedicated message resource setting for notifications.

* **Bug Fixes**
  * Reminder handling now stops earlier when consent has already been processed, reducing duplicate reminder attempts.
  * Notification payloads now carry the expected resource and action values consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->