### PR TITLE
fix(deps): remove duplicate vulnerable crypto pin and update all packages

### DIFF
--- a/Dan.Common.UnitTest/Dan.Common.UnitTest.csproj
+++ b/Dan.Common.UnitTest/Dan.Common.UnitTest.csproj
@@ -9,10 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-        <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+        <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+        <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+        <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
         <PackageReference Include="coverlet.collector" Version="10.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -33,21 +33,21 @@
     <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.10" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NJsonSchema" Version="11.6.1" />
     <PackageReference Include="NJsonSchema.NewtonsoftJson" Version="11.6.1" />
 
     <PackageReference Include="Polly.Caching.Distributed" Version="3.0.1" />
     <PackageReference Include="Polly.Caching.Serialization.Json" Version="3.0.0" />
-    <PackageReference Include="StackExchange.Redis" Version="2.13.17" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
+    <PackageReference Include="StackExchange.Redis" Version="3.1.3" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
+++ b/Dan.Core.UnitTest/Dan.Core.UnitTest.csproj
@@ -10,19 +10,19 @@
 
   <ItemGroup>
     <!-- FluentAssertions v8.0 requires a subscription... -->
-    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.5.0" />
     <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Polly.Caching.Memory" Version="3.0.2" />
     <!-- Pin transitive (via Dan.Core WCF stack) to patched version, see GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -37,32 +37,30 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Monitor.Query" Version="1.7.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageReference Include="GitInfo" Version="3.6.0">
+    <PackageReference Include="GitInfo" Version="3.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JmesPath.Net" Version="1.1.0" />
     <PackageReference Include="jose-jwt" Version="5.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.61.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.CosmosDB" Version="4.16.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.8" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.19.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.10" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.22.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.22.0" />
     <PackageReference Include="Parquet.Net" Version="6.0.3" />
-    <PackageReference Include="Polly" Version="8.6.6" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
-    <!-- Pin transitive (WCF stack) to patched version, see GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf -->
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
-    
+    <PackageReference Include="Polly" Version="8.7.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.22.0" />
+
     <!-- WCF related things -->
     <PackageReference Include="System.Private.ServiceModel" Version="4.10.3" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="6.0.0" />
@@ -76,7 +74,7 @@
          Snappier (via Parquet.Net): GHSA-pggp-6c3x-2xmx, fixed in 1.3.1
          System.Security.Cryptography.Xml (via System.ServiceModel.*): GHSA-37gx-xxp4-5rgx / GHSA-w3x6-4m5h-cxqf (CVE-2026-33116), fixed in 10.0.6 -->
     <PackageReference Include="Snappier" Version="1.3.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" />
 
   </ItemGroup>
   <ItemGroup>

--- a/Dan.PluginTest/Dan.PluginTest.csproj
+++ b/Dan.PluginTest/Dan.PluginTest.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" OutputItemType="Analyzer" />
+        <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" OutputItemType="Analyzer" />
         <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.3.0" />
     </ItemGroup>
     <ItemGroup>


### PR DESCRIPTION
## Summary

- **Security fix:** `Dan.Core.csproj` had a duplicate `PackageReference` for `System.Security.Cryptography.Xml` (10.0.8 and 10.0.9). NuGet resolved the older 10.0.8 (with a NU1504 duplicate warning), silently regressing five High-severity advisories: GHSA-cvvh-rhrc-wg4q, GHSA-g8r8-53c2-pm3f, GHSA-23rf-6693-g89p, GHSA-8q5v-6pqq-x66h, GHSA-mmjf-rqrv-855v. The duplicate is removed and the remaining pin bumped to **10.0.10** (also bumped the direct reference in `Dan.Core.UnitTest`). The pin is still required on master because the WCF stack (`System.ServiceModel.*`, used by the legacy A2 correspondence path) pulls it in transitively.
- **All other outdated packages updated**, including two major bumps:
  - `Microsoft.ApplicationInsights.WorkerService` 2.23.0 → 3.1.2 (Dan.Core, Dan.Common)
  - `StackExchange.Redis` 2.13.17 → 3.1.3 (Dan.Common)
  - Minor/patch: Cosmos 3.62.0, Functions Worker SDK 2.1.0, Microsoft.IdentityModel/JWT 8.22.0, Microsoft.Extensions.* 10.0.10, Polly 8.7.0, GitInfo 3.6.1, SourceLink 10.0.301, MSTest 4.3.3, Test.Sdk 18.8.1, AwesomeAssertions 9.5.0

## Verification

- `dotnet list Dan.sln package --vulnerable --include-transitive` → no vulnerable packages in any project
- `dotnet list Dan.sln package --outdated` → no remaining updates
- Release build succeeds with 0 errors (remaining warnings are pre-existing)
- Both unit test suites pass (Dan.Core.UnitTest ≥123 tests, Dan.Common.UnitTest all cases) via Microsoft.Testing.Platform with `--minimum-expected-tests` floors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application and test components to newer dependency versions.
  * Refreshed testing, Azure Functions, telemetry, caching, security, and data-access packages.
  * Updated build and source-linking tooling for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->