### PR TITLE
fix(deps): revert Microsoft.ApplicationInsights.WorkerService to 2.23.0 (hotfix for startup TypeLoadException)

### DIFF
--- a/Dan.Common/Dan.Common.csproj
+++ b/Dan.Common/Dan.Common.csproj
@@ -33,7 +33,9 @@
     <PackageReference Include="AsyncKeyedLock" Version="8.0.2" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <!-- Keep on 2.x: AI 3.x (OpenTelemetry rewrite) drops ITelemetryInitializer and breaks
+         Microsoft.Azure.Functions.Worker.ApplicationInsights at host startup -->
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Core.NewtonsoftJson" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />

--- a/Dan.Core/Dan.Core.csproj
+++ b/Dan.Core/Dan.Core.csproj
@@ -43,7 +43,9 @@
     </PackageReference>
     <PackageReference Include="JmesPath.Net" Version="1.1.0" />
     <PackageReference Include="jose-jwt" Version="5.3.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="3.1.2" />
+    <!-- Keep on 2.x: AI 3.x (OpenTelemetry rewrite) drops ITelemetryInitializer and breaks
+         Microsoft.Azure.Functions.Worker.ApplicationInsights at host startup -->
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.51.0" />


### PR DESCRIPTION
## Summary
- Reverts the `Microsoft.ApplicationInsights.WorkerService` 2.23.0 → 3.1.2 bump from #316, which took the function app down at startup with:
  ```
  System.TypeLoadException: Could not load type 'Microsoft.ApplicationInsights.Extensibility.ITelemetryInitializer'
  from assembly 'Microsoft.ApplicationInsights, Version=3.1.2.115'
  ```
- Application Insights 3.x is an OpenTelemetry-based rewrite that removes classic 2.x types (`ITelemetryInitializer` among them). `Microsoft.Azure.Functions.Worker.ApplicationInsights` (2.51.0) is compiled against the 2.x API, so once NuGet unified `Microsoft.ApplicationInsights` up to 3.1.2 the worker crashed before any function could load.
- 2.23.0 is the latest 2.x release and has no known security advisories — nothing from the vulnerability fixes in #316 is lost. A comment in both csproj files now warns against 3.x bumps until the Functions worker integration supports AI 3.x.

## Why CI didn't catch it
Unit tests never boot the Functions host; the failure is runtime-only, at worker startup.

## Verification
- Local host smoke test via `dotnet run` in Dan.Core: **26 functions loaded, worker process started and initialized, no exceptions**
- Build clean, all 141 unit tests pass (121 Dan.Core + 20 Dan.Common)
- `dotnet list package --vulnerable --include-transitive`: no vulnerable packages in any project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Azure Functions Application Insights by aligning the Application Insights Worker Service version.
* **Chores**
  * Pinned the telemetry component to a compatible release for more consistent application monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->